### PR TITLE
Fixed uninitialized PRTActor crash

### DIFF
--- a/Source/Vitruvio/Public/PRTActor.h
+++ b/Source/Vitruvio/Public/PRTActor.h
@@ -305,13 +305,13 @@ public:
 
 	///////////////////////////////////////////////
 
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PRT|Components")
+	UPROPERTY(BlueprintReadWrite, Category = "PRT|Components")
 	UStaticMeshComponent* PRTStaticMesh;
 
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PRT|Components")
+	UPROPERTY(BlueprintReadWrite, Category = "PRT|Components")
 	UProceduralMeshComponent* PRTProceduralMesh;
 
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PRT|Components")
+	UPROPERTY(BlueprintReadWrite, Category = "PRT|Components")
 	UBoxComponent* PRTCollisionBox;
 
 	///////////////////////////////////////////////


### PR DESCRIPTION
The crash happened because the ProceduralMeshComponent Visible in default state somehow crashes. It does not need to be visible anyways.