### PR TITLE
Always force generate

### DIFF
--- a/Source/Vitruvio/Private/PRTDetail.cpp
+++ b/Source/Vitruvio/Private/PRTDetail.cpp
@@ -99,7 +99,7 @@ FReply FPRTDetail::HandleGenerateClicked() const
 {
 	APRTActor* PrtActor = PRTActor.Get();
 
-	PrtActor->Generate();
+	PrtActor->Generate(true);
 
 	return FReply::Handled();
 }


### PR DESCRIPTION
This will cause a regeneration even if no attributes have changed. The underlying issue is that somehow the generated mesh triangles are not updated correctly. Not worth investigating more as this is a border case anyways.