### PR TITLE
Benj9250/mesh cooking

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -267,7 +267,8 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 
 			// Cook actors after all models have been generated and their meshes constructed
 			FScopedSlowTask CookTask(Actors.Num(), FText::FromString("Cooking models..."));
-
+			CookTask.MakeDialog();
+			
 			FMaterialCache MaterialCache;
 			FTextureCache TextureCache;
 			FStaticMeshCache MeshCache;

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -257,6 +257,9 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 
 			if (PickContentPathDlg->ShowModal() == EAppReturnType::Cancel)
 			{
+				IsCooking = false;
+				VitruvioModule::Get().OnGenerateCompleted.Remove(ModelsGeneratedHandle);
+				ModelsGeneratedHandle.Reset();
 				return;
 			}
 			FString CookPath = PickContentPathDlg->GetPath().ToString();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -188,12 +188,13 @@ UStaticMesh* SaveStaticMesh(UStaticMesh* Mesh, const FString& Path, FStaticMeshC
 	PersistedMesh->InitResources();
 
 	FMeshDescription* OriginalMeshDescription = Mesh->GetMeshDescription(0);
-	FStaticMeshAttributes MeshAttributes(*OriginalMeshDescription);
+	FMeshDescription NewMeshDescription(*OriginalMeshDescription);
+	FStaticMeshAttributes MeshAttributes(NewMeshDescription);
 
 	// Copy Materials
 	TMap<UMaterialInstanceConstant*, FName> MaterialSlots;
 
-	const auto PolygonGroups = OriginalMeshDescription->PolygonGroups();
+	const auto PolygonGroups = NewMeshDescription.PolygonGroups();
 	for (const auto& PolygonGroupId : PolygonGroups.GetElementIDs())
 	{
 		const FName MaterialName = MeshAttributes.GetPolygonGroupMaterialSlotNames()[PolygonGroupId];
@@ -223,7 +224,7 @@ UStaticMesh* SaveStaticMesh(UStaticMesh* Mesh, const FString& Path, FStaticMeshC
 
 	// Build the Static Mesh
 	TArray<const FMeshDescription*> MeshDescriptions;
-	MeshDescriptions.Add(OriginalMeshDescription);
+	MeshDescriptions.Add(&NewMeshDescription);
 	PersistedMesh->BuildFromMeshDescriptions(MeshDescriptions);
 	PersistedMesh->PostEditChange();
 	PersistedMesh->MarkPackageDirty();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -1,6 +1,7 @@
 #include "VitruvioCooker.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetToolsModule.h"
 #include "Dialogs/DlgPickPath.h"
 #include "Factories/MaterialInstanceConstantFactoryNew.h"
 #include "GeneratedModelHISMComponent.h"
@@ -66,9 +67,12 @@ UTexture2D* SaveTexture(UTexture2D* Original, const FString& Path, FTextureCache
 		return TextureCache[Original];
 	}
 
-	FString TexturePath = FPaths::Combine(Path, TEXT("Textures"), Original->GetName());
-	UPackage* TexturePackage = CreatePackage(*TexturePath);
-	UTexture2D* NewTexture = NewObject<UTexture2D>(TexturePackage, *Original->GetName(), RF_Public | RF_Standalone);
+	FString TexturePackagePathSuggestion = FPaths::Combine(Path, TEXT("Textures"), Original->GetName());
+	FString TextureName;
+	FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+	AssetToolsModule.Get().CreateUniqueAssetName(TexturePackagePathSuggestion, TEXT(""), TexturePackagePathSuggestion, TextureName);
+	UPackage* TexturePackage = CreatePackage(*TexturePackagePathSuggestion);
+	UTexture2D* NewTexture = NewObject<UTexture2D>(TexturePackage, *TextureName, RF_Public | RF_Standalone);
 
 	NewTexture->PlatformData = new FTexturePlatformData();
 	NewTexture->PlatformData->SizeX = Original->PlatformData->SizeX;
@@ -113,9 +117,11 @@ UMaterialInstanceConstant* SaveMaterial(UMaterialInstanceDynamic* Material, cons
 		return MaterialCache[Material];
 	}
 
-	const FString MaterialName = Material->GetName();
-	const FString MaterialPackagePath = FPaths::Combine(Path, TEXT("Materials"), MaterialName);
-	UPackage* MaterialPackage = CreatePackage(*MaterialPackagePath);
+	FString MaterialPackagePathSuggestion = FPaths::Combine(Path, TEXT("Materials"), Material->GetName());
+	FString MaterialName;
+	FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+	AssetToolsModule.Get().CreateUniqueAssetName(MaterialPackagePathSuggestion, TEXT(""), MaterialPackagePathSuggestion, MaterialName);
+	UPackage* MaterialPackage = CreatePackage(*MaterialPackagePathSuggestion);
 
 	UMaterialInstanceConstantFactoryNew* MaterialFactory = NewObject<UMaterialInstanceConstantFactoryNew>();
 	MaterialFactory->InitialParent = Material->Parent;
@@ -172,9 +178,12 @@ UStaticMesh* SaveStaticMesh(UStaticMesh* Mesh, const FString& Path, FStaticMeshC
 	}
 
 	// Create new StaticMesh Asset
-	const FString StaticMeshName = Mesh->GetName();
-	const FString PackageName = FPaths::Combine(Path, TEXT("Geometry"), StaticMeshName);
-	UPackage* MeshPackage = CreatePackage(*PackageName);
+	FString PackageNameSuggestion = FPaths::Combine(Path, TEXT("Geometry"), Mesh->GetName());
+	FString StaticMeshName;
+	FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+	AssetToolsModule.Get().CreateUniqueAssetName(PackageNameSuggestion, TEXT(""), PackageNameSuggestion, StaticMeshName);
+
+	UPackage* MeshPackage = CreatePackage(*PackageNameSuggestion);
 	UStaticMesh* PersistedMesh = NewObject<UStaticMesh>(MeshPackage, *StaticMeshName, RF_Public | RF_Standalone);
 	PersistedMesh->InitResources();
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -275,7 +275,12 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 			for (AActor* Actor : Actors)
 			{
 				CookTask.EnterProgressFrame(1);
-
+				
+				UVitruvioComponent* VitruvioComponent = Actor->FindComponentByClass<UVitruvioComponent>();
+				if (!VitruvioComponent)
+				{
+					continue;
+				}
 				AActor* OldAttachParent = Actor->GetAttachParentActor();
 
 				// Spawn new Actor with persisted geometry

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -93,7 +93,7 @@ UTexture2D* SaveTexture(UTexture2D* Original, const FString& Path, FTextureCache
 	const uint8* SourcePixels = static_cast<const uint8*>(OriginalMip.BulkData.LockReadOnly());
 	Mip->BulkData.Lock(LOCK_READ_WRITE);
 
-	void* TextureData = Mip->BulkData.Realloc(CalculateImageBytes(Mip->SizeX, Mip->SizeY, 0, NewTexture->PlatformData->PixelFormat));
+	void* TextureData = Mip->BulkData.Realloc(OriginalMip.BulkData.GetBulkDataSize());
 	FMemory::Memcpy(TextureData, SourcePixels, OriginalMip.BulkData.GetBulkDataSize());
 	Mip->BulkData.Unlock();
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -285,10 +285,6 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 
 				// Spawn new Actor with persisted geometry
 				AActor* CookedActor = Actor->GetWorld()->SpawnActor<AActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
-				if (OldAttachParent)
-				{
-					CookedActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
-				}
 
 				USceneComponent* RootComponent = NewObject<USceneComponent>(CookedActor, "Root");
 				CookedActor->AddOwnedComponent(RootComponent);
@@ -298,6 +294,11 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 				RootComponent->SetWorldRotation(Actor->GetActorRotation());
 				RootComponent->SetWorldLocation(Actor->GetActorLocation());
 				RootComponent->RegisterComponent();
+
+				if (OldAttachParent)
+				{
+					CookedActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
+				}
 
 				// Persist Mesh
 				UGeneratedModelStaticMeshComponent* StaticMeshComponent = Actor->FindComponentByClass<UGeneratedModelStaticMeshComponent>();


### PR DESCRIPTION
Fixes several issues for cooking:
- If cooking result was stored in a folder with assets the old assets might have been overwritten
- The cooking process sometimes modified existing meshes
- Dialog flicker during cooking removed by using a modal dialog
- Proper re-attachement to old attach parent