### PR TITLE
Bneukom/attribute eval

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealLogHandler.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealLogHandler.cpp
@@ -19,14 +19,14 @@ DEFINE_LOG_CATEGORY(UnrealPrtLog)
 
 TArray<FLogMessage> UnrealLogHandler::PopMessages()
 {
-	TArray<FLogMessage> Result = Messages;
+	TArray<FLogMessage> Result(Messages);
 	Messages.Empty();
 	return Result;
 }
 
 void UnrealLogHandler::handleLogEvent(const wchar_t* msg, prt::LogLevel level)
 {
-	const FString MessageString(msg);
+	const FString MessageString(WCHAR_TO_TCHAR(msg));
 	Messages.Push({MessageString, level});
 
 	switch (level)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AnnotationParsing.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AnnotationParsing.cpp
@@ -215,7 +215,7 @@ void ParseAttributeAnnotations(const prt::RuleFileInfo::Entry* AttributeInfo, UR
 
 		if (!std::wcscmp(Name, ANNOT_HIDDEN))
 		{
-			InAttribute.Hidden = true;
+			InAttribute.bHidden = true;
 		}
 		else if (!std::wcscmp(Name, ANNOT_ORDER))
 		{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.cpp
@@ -138,7 +138,7 @@ TMap<FString, URuleAttribute*> ConvertAttributeMap(const AttributeMapUPtr& Attri
 
 			ParseAttributeAnnotations(AttrInfo, *Attribute, Outer);
 
-			if (!Attribute->Hidden)
+			if (!Attribute->bHidden)
 			{
 				UnrealAttributeMap.Add(AttributeName, Attribute);
 			}
@@ -155,7 +155,7 @@ AttributeMapUPtr CreateAttributeMap(const TMap<FString, URuleAttribute*>& Attrib
 	{
 		const URuleAttribute* Attribute = AttributeEntry.Value;
 
-		if (!Attribute->UserSet) continue;
+		if (!Attribute->bUserSet) continue;
 
 		if (const UFloatAttribute* FloatAttribute = Cast<UFloatAttribute>(Attribute))
 		{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.cpp
@@ -155,6 +155,8 @@ AttributeMapUPtr CreateAttributeMap(const TMap<FString, URuleAttribute*>& Attrib
 	{
 		const URuleAttribute* Attribute = AttributeEntry.Value;
 
+		if (!Attribute->UserSet) continue;
+
 		if (const UFloatAttribute* FloatAttribute = Cast<UFloatAttribute>(Attribute))
 		{
 			AttributeMapBuilder->setFloat(TCHAR_TO_WCHAR(*Attribute->Name), FloatAttribute->Value);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -536,22 +536,6 @@ FConvertedGenerateResult UVitruvioComponent::BuildResult(FGenerateResultDescript
 														 TMap<Vitruvio::FMaterialAttributeContainer, UMaterialInstanceDynamic*>& MaterialCache,
 														 TMap<FString, Vitruvio::FTextureData>& TextureCache)
 {
-	auto CachedMaterial = [this, &MaterialCache, &TextureCache](const Vitruvio::FMaterialAttributeContainer& MaterialAttributes, const FName& Name,
-																UObject* Outer) {
-		if (MaterialCache.Contains(MaterialAttributes))
-		{
-			return MaterialCache[MaterialAttributes];
-		}
-		else
-		{
-			const FName UniqueMaterialName(Name);
-			UMaterialInstanceDynamic* Material = Vitruvio::GameThread_CreateMaterialInstance(Outer, UniqueMaterialName, OpaqueParent, MaskedParent,
-																							 TranslucentParent, MaterialAttributes, TextureCache);
-			MaterialCache.Add(MaterialAttributes, Material);
-			return Material;
-		}
-	};
-
 	// build all meshes
 	for (auto& IdAndMesh : GenerateResult.Meshes)
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -775,7 +775,7 @@ void UVitruvioComponent::EvalRuleAttributes(bool ForceRegenerate)
 
 	bAttributesReady = false;
 
-	FAttributeMapResult AttributesResult = VitruvioModule::Get().EvalRuleAttributesAsync(InitialShape->GetFaces(), Rpk, RandomSeed);
+	FAttributeMapResult AttributesResult = VitruvioModule::Get().EvalRuleAttributesAsync(InitialShape->GetFaces(), Rpk, Vitruvio::CreateAttributeMap(Attributes), RandomSeed);
 
 	EvalAttributesInvalidationToken = AttributesResult.Token;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -608,7 +608,7 @@ void UVitruvioComponent::Generate()
 	// and regenerate afterwards
 	if (HasValidInputData() && !bAttributesReady)
 	{
-		EvalRuleAttributes(true);
+		EvaluateRuleAttributes(true);
 		return;
 	}
 
@@ -732,7 +732,7 @@ void UVitruvioComponent::OnPropertyChanged(UObject* Object, FPropertyChangedEven
 
 	if (HasValidInputData() && !bAttributesReady)
 	{
-		EvalRuleAttributes();
+		EvaluateRuleAttributes();
 	}
 }
 
@@ -760,7 +760,7 @@ void UVitruvioComponent::SetInitialShapeType(const TSubclassOf<UInitialShape>& T
 
 #endif // WITH_EDITOR
 
-void UVitruvioComponent::EvalRuleAttributes(bool ForceRegenerate)
+void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate)
 {
 	check(Rpk);
 	check(InitialShape);
@@ -775,7 +775,7 @@ void UVitruvioComponent::EvalRuleAttributes(bool ForceRegenerate)
 
 	bAttributesReady = false;
 
-	FAttributeMapResult AttributesResult = VitruvioModule::Get().EvalRuleAttributesAsync(InitialShape->GetFaces(), Rpk, Vitruvio::CreateAttributeMap(Attributes), RandomSeed);
+	FAttributeMapResult AttributesResult = VitruvioModule::Get().EvaluateRuleAttributesAsync(InitialShape->GetFaces(), Rpk, Vitruvio::CreateAttributeMap(Attributes), RandomSeed);
 
 	EvalAttributesInvalidationToken = AttributesResult.Token;
 
@@ -790,7 +790,7 @@ void UVitruvioComponent::EvalRuleAttributes(bool ForceRegenerate)
 		EvalAttributesInvalidationToken.Reset();
 		if (Result.Token->IsReEvaluateRequested())
 		{
-			EvalRuleAttributes(ForceRegenerate);
+			EvaluateRuleAttributes(ForceRegenerate);
 		}
 		else
 		{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -186,6 +186,7 @@ FString UniqueComponentName(const FString& Name, TMap<FString, int32>& UsedNames
 } // namespace
 
 UVitruvioComponent::FOnHierarchyChanged UVitruvioComponent::OnHierarchyChanged;
+UVitruvioComponent::FOnAttributesChanged UVitruvioComponent::OnAttributesChanged;
 
 UVitruvioComponent::UVitruvioComponent()
 {
@@ -508,7 +509,7 @@ void UVitruvioComponent::NotifyAttributesChanged()
 #if WITH_EDITOR
 	// Notify possible listeners (eg. Details panel) about changes to the Attributes
 	FPropertyChangedEvent PropertyEvent(GetClass()->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UVitruvioComponent, Attributes)));
-	FCoreUObjectDelegates::OnObjectPropertyChanged.Broadcast(this, PropertyEvent);
+	OnAttributesChanged.Broadcast(this, PropertyEvent);
 #endif
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -474,10 +474,10 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 
 		for (auto Attribute : Attributes)
 		{
-			if (OldAttributes.Contains(Attribute.Key) && OldAttributes[Attribute.Key]->UserSet)
+			if (OldAttributes.Contains(Attribute.Key) && OldAttributes[Attribute.Key]->bUserSet)
 			{
 				Attribute.Value->CopyValue(OldAttributes[Attribute.Key]);
-				Attribute.Value->UserSet = true;
+				Attribute.Value->bUserSet = true;
 			}
 		}
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -425,7 +425,7 @@ FAttributeMapResult VitruvioModule::EvalRuleAttributesAsync(const TArray<FInitia
 {
 	check(RulePackage);
 
-	FAttributeMapResult::FTokenPtr InvalidationToken = MakeShared<FInvalidationToken>();
+	FAttributeMapResult::FTokenPtr InvalidationToken = MakeShared<FEvalAttributesToken>();
 
 	if (!Initialized)
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -150,7 +150,7 @@ void SetInitialShapeGeometry(const InitialShapeBuilderUPtr& InitialShapeBuilder,
 	}
 }
 
-AttributeMapUPtr EvalRuleAttribtues(const std::wstring& RuleFile, const std::wstring& StartRule, AttributeMapUPtr Attributes, const ResolveMapSPtr& ResolveMapPtr,
+AttributeMapUPtr EvaluateRuleAttribtues(const std::wstring& RuleFile, const std::wstring& StartRule, AttributeMapUPtr Attributes, const ResolveMapSPtr& ResolveMapPtr,
 										   const TArray<FInitialShapeFace>& InitialShape, prt::Cache* Cache, const int32 RandomSeed)
 {
 	AttributeMapBuilderUPtr UnrealCallbacksAttributeBuilder(prt::AttributeMapBuilder::create());
@@ -419,7 +419,7 @@ FGenerateResultDescription VitruvioModule::Generate(const TArray<FInitialShapeFa
 	return FGenerateResultDescription {OutputHandler->GetInstances(), OutputHandler->GetMeshes(), OutputHandler->GetNames() };
 }
 
-FAttributeMapResult VitruvioModule::EvalRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
+FAttributeMapResult VitruvioModule::EvaluateRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
 															AttributeMapUPtr Attributes, const int32 RandomSeed) const
 {
 	check(RulePackage);
@@ -457,7 +457,7 @@ FAttributeMapResult VitruvioModule::EvalRuleAttributesAsync(const TArray<FInitia
 		}
 
 		AttributeMapUPtr DefaultAttributeMap(
-			EvalRuleAttribtues(RuleFile.c_str(), StartRule.c_str(), std::move(Attributes), ResolveMap, InitialShape, PrtCache.get(), RandomSeed));
+			EvaluateRuleAttribtues(RuleFile.c_str(), StartRule.c_str(), std::move(Attributes), ResolveMap, InitialShape, PrtCache.get(), RandomSeed));
 
 		LoadAttributesCounter.Decrement();
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -150,7 +150,7 @@ void SetInitialShapeGeometry(const InitialShapeBuilderUPtr& InitialShapeBuilder,
 	}
 }
 
-AttributeMapUPtr GetDefaultAttributeValues(const std::wstring& RuleFile, const std::wstring& StartRule, const ResolveMapSPtr& ResolveMapPtr,
+AttributeMapUPtr EvalAttributeValues(const std::wstring& RuleFile, const std::wstring& StartRule, const ResolveMapSPtr& ResolveMapPtr,
 										   const TArray<FInitialShapeFace>& InitialShape, prt::Cache* Cache, const int32 RandomSeed)
 {
 	AttributeMapBuilderUPtr UnrealCallbacksAttributeBuilder(prt::AttributeMapBuilder::create());
@@ -420,7 +420,7 @@ FGenerateResultDescription VitruvioModule::Generate(const TArray<FInitialShapeFa
 	return FGenerateResultDescription {OutputHandler->GetInstances(), OutputHandler->GetMeshes(), OutputHandler->GetNames() };
 }
 
-FAttributeMapResult VitruvioModule::LoadDefaultRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
+FAttributeMapResult VitruvioModule::EvalRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
 																   const int32 RandomSeed) const
 {
 	check(RulePackage);
@@ -458,7 +458,7 @@ FAttributeMapResult VitruvioModule::LoadDefaultRuleAttributesAsync(const TArray<
 		}
 
 		AttributeMapUPtr DefaultAttributeMap(
-			GetDefaultAttributeValues(RuleFile.c_str(), StartRule.c_str(), ResolveMap, InitialShape, PrtCache.get(), RandomSeed));
+			EvalAttributeValues(RuleFile.c_str(), StartRule.c_str(), ResolveMap, InitialShape, PrtCache.get(), RandomSeed));
 
 		LoadAttributesCounter.Decrement();
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -124,10 +124,10 @@ public:
 	int GroupOrder;
 
 	UPROPERTY()
-	bool Hidden;
+	bool bHidden;
 
 	UPROPERTY()
-	bool UserSet;
+	bool bUserSet;
 
 	void SetAnnotation(UAttributeAnnotation* InAnnotation)
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -230,9 +230,9 @@ public:
 	UPROPERTY(EditAnywhere)
 	TArray<double> Values;
 
-	UStringEnumAnnotation* GetEnumAnnotation() const
+	UFloatEnumAnnotation* GetEnumAnnotation() const
 	{
-		return Cast<UStringEnumAnnotation>(Annotation);
+		return Cast<UFloatEnumAnnotation>(Annotation);
 	}
 
 	UColorAnnotation* GetColorAnnotation() const
@@ -277,11 +277,6 @@ class VITRUVIO_API UBoolArrayAttribute final : public URuleAttribute
 public:
 	UPROPERTY(EditAnywhere)
 	TArray<bool> Values;
-
-	UStringEnumAnnotation* GetEnumAnnotation() const
-	{
-		return Cast<UStringEnumAnnotation>(Annotation);
-	}
 
 	UColorAnnotation* GetColorAnnotation() const
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -235,9 +235,9 @@ public:
 		return Cast<UFloatEnumAnnotation>(Annotation);
 	}
 
-	UColorAnnotation* GetColorAnnotation() const
+	URangeAnnotation* GetRangeAnnotation() const
 	{
-		return Cast<UColorAnnotation>(Annotation);
+		return Cast<URangeAnnotation>(Annotation);
 	}
 
 	void CopyValue(const URuleAttribute* FromAttribute) override

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -143,7 +143,7 @@ class VITRUVIO_API UStringAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
+	UPROPERTY(EditAnywhere)
 	FString Value;
 
 	UStringEnumAnnotation* GetEnumAnnotation() const
@@ -201,7 +201,7 @@ class VITRUVIO_API UFloatAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
+	UPROPERTY(EditAnywhere)
 	double Value;
 
 	UFloatEnumAnnotation* GetEnumAnnotation() const
@@ -259,7 +259,7 @@ class VITRUVIO_API UBoolAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
+	UPROPERTY(EditAnywhere)
 	bool Value;
 
 	void CopyValue(const URuleAttribute* FromAttribute) override

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -126,6 +126,9 @@ public:
 	UPROPERTY()
 	bool Hidden;
 
+	UPROPERTY()
+	bool UserSet;
+
 	void SetAnnotation(UAttributeAnnotation* InAnnotation)
 	{
 		Annotation = InAnnotation;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -42,7 +42,6 @@ struct FConvertedGenerateResult
 struct FAttributesEvaluation
 {
 	FAttributeMapPtr AttributeMap;
-	bool bKeepOldAttributes;
 	bool bForceRegenerate;
 };
 
@@ -192,10 +191,9 @@ public:
 	/**
 	 * Evaluate rule attributes.
 	 *
-	 * @param KeepOldAttributeValues Whether to keep old attribute values
 	 * @param ForceRegenerate Whether to force regenerate even if generate automatically is set to false
 	 */
-	void EvalRuleAttributes(bool KeepOldAttributeValues = false, bool ForceRegenerate = false);
+	void EvalRuleAttributes(bool ForceRegenerate = false);
 
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*) static FOnHierarchyChanged OnHierarchyChanged;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -193,7 +193,7 @@ public:
 	 *
 	 * @param ForceRegenerate Whether to force regenerate even if generate automatically is set to false
 	 */
-	void EvalRuleAttributes(bool ForceRegenerate = false);
+	void EvaluateRuleAttributes(bool ForceRegenerate = false);
 
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*) static FOnHierarchyChanged OnHierarchyChanged;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -51,8 +51,6 @@ class VITRUVIO_API UVitruvioComponent : public UActorComponent
 {
 	GENERATED_BODY()
 
-	TAtomic<bool> EvaluatingAttributes = false;
-
 	UPROPERTY()
 	bool bValidRandomSeed = false;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -195,7 +195,11 @@ public:
 	 */
 	void EvaluateRuleAttributes(bool ForceRegenerate = false);
 
-	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*) static FOnHierarchyChanged OnHierarchyChanged;
+	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*);
+	static FOnHierarchyChanged OnHierarchyChanged;
+
+	DECLARE_MULTICAST_DELEGATE_TwoParams(FOnAttributesChanged, UObject*, struct FPropertyChangedEvent&);
+	static FOnAttributesChanged OnAttributesChanged;
 
 	virtual void PostLoad() override;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -39,7 +39,7 @@ struct FConvertedGenerateResult
 	TArray<FInstance> Instances;
 };
 
-struct FLoadAttributes
+struct FAttributesEvaluation
 {
 	FAttributeMapPtr AttributeMap;
 	bool bKeepOldAttributes;
@@ -51,7 +51,7 @@ class VITRUVIO_API UVitruvioComponent : public UActorComponent
 {
 	GENERATED_BODY()
 
-	TAtomic<bool> LoadingAttributes = false;
+	TAtomic<bool> EvaluatingAttributes = false;
 
 	UPROPERTY()
 	bool bValidRandomSeed = false;
@@ -192,12 +192,12 @@ public:
 	void RemoveGeneratedMeshes();
 
 	/**
-	 * Load the default attributes.
+	 * Evaluate rule attributes.
 	 *
 	 * @param KeepOldAttributeValues Whether to keep old attribute values
 	 * @param ForceRegenerate Whether to force regenerate even if generate automatically is set to false
 	 */
-	void LoadDefaultAttributes(bool KeepOldAttributeValues = false, bool ForceRegenerate = false);
+	void EvalRuleAttributes(bool KeepOldAttributeValues = false, bool ForceRegenerate = false);
 
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*) static FOnHierarchyChanged OnHierarchyChanged;
 
@@ -234,10 +234,10 @@ private:
 	int32 RandomSeed;
 
 	TQueue<FGenerateResultDescription> GenerateQueue;
-	TQueue<FLoadAttributes> LoadAttributesQueue;
+	TQueue<FAttributesEvaluation> AttributesEvaluationQueue;
 
 	FGenerateResult::FTokenPtr GenerateToken;
-	FAttributeMapResult::FTokenPtr LoadAttributesInvalidationToken;
+	FAttributeMapResult::FTokenPtr EvalAttributesInvalidationToken;
 
 	bool HasGeneratedMesh = false;
 
@@ -246,7 +246,7 @@ private:
 	void NotifyAttributesChanged();
 
 	void ProcessGenerateQueue();
-	void ProcessLoadAttributesQueue();
+	void ProcessAttributesEvaluationQueue();
 
 	FConvertedGenerateResult BuildResult(FGenerateResultDescription& GenerateResult,
 										 TMap<Vitruvio::FMaterialAttributeContainer, UMaterialInstanceDynamic*>& MaterialCache,

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -63,6 +63,23 @@ private:
 	FThreadSafeBool bIsInvalid = false;
 };
 
+class FEvalAttributesToken : public FInvalidationToken
+{
+public:
+	void RequestReEvaluateAttributes()
+	{
+		bRequestReEvaluateAttributes = true;
+	}
+
+	bool IsReEvaluateRequested() const
+	{
+		return bRequestReEvaluateAttributes;
+	}
+
+private:
+	FThreadSafeBool bRequestReEvaluateAttributes = false;
+};
+
 class FGenerateToken : public FInvalidationToken
 {
 public:
@@ -99,7 +116,7 @@ public:
 };
 
 using FGenerateResult = TResult<FGenerateResultDescription, FGenerateToken>;
-using FAttributeMapResult = TResult<FAttributeMapPtr, FInvalidationToken>;
+using FAttributeMapResult = TResult<FAttributeMapPtr, FEvalAttributesToken>;
 
 class VitruvioModule final : public IModuleInterface, public FGCObject
 {

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -139,14 +139,14 @@ public:
 													 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
 
 	/**
-	 * \brief Asynchronously loads the default attribute values for the given initial shape and rule package
+	 * \brief Asynchronously evaluates attributes for the given initial shape and rule package.
 	 *
 	 * \param InitialShape
 	 * \param RulePackage
 	 * \param RandomSeed
 	 * \return
 	 */
-	VITRUVIO_API FAttributeMapResult LoadDefaultRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
+	VITRUVIO_API FAttributeMapResult EvalRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
 																	const int32 RandomSeed) const;
 
 	/**

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -164,7 +164,7 @@ public:
 	 * \param RandomSeed
 	 * \return
 	 */
-	VITRUVIO_API FAttributeMapResult EvalRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
+	VITRUVIO_API FAttributeMapResult EvaluateRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
 															 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
 
 	/**

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -160,11 +160,12 @@ public:
 	 *
 	 * \param InitialShape
 	 * \param RulePackage
+	 * \param Attributes
 	 * \param RandomSeed
 	 * \return
 	 */
 	VITRUVIO_API FAttributeMapResult EvalRuleAttributesAsync(const TArray<FInitialShapeFace>& InitialShape, URulePackage* RulePackage,
-																	const int32 RandomSeed) const;
+															 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
 
 	/**
 	 * \return whether PRT is initialized meaning installed and ready to use. Before initialization generation is not possible and will

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -90,7 +90,7 @@ TSharedPtr<SPropertyComboBox<V>> CreateArrayEnumWidget(Attr* Attribute, An* Anno
 	V CurrentValue;
 	PropertyHandle->GetValue(CurrentValue);
 	auto InitialSelectedIndex = Annotation->Values.IndexOfByPredicate([&CurrentValue](const V& Value) { return Value == CurrentValue; });
-	InitialSelectedIndex = FMath::Min(InitialSelectedIndex, 0);
+	InitialSelectedIndex = FMath::Max(InitialSelectedIndex, 0);
 	auto InitialSelectedValue = SharedPtrValues[InitialSelectedIndex];
 
 	auto ValueWidget = SNew(SPropertyComboBox<V>)

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -66,7 +66,7 @@ void UpdateAttributeValue(UVitruvioComponent* VitruvioActor, A* Attribute, const
 {
 	Attribute->Value = Value;
 	Attribute->UserSet = true;
-	VitruvioActor->EvalRuleAttributes(VitruvioActor->GenerateAutomatically);
+	VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
 }
 
 bool IsVitruvioComponentSelected(const TArray<TWeakObjectPtr<UObject>>& ObjectsBeingCustomized, UVitruvioComponent*& OutComponent)
@@ -533,7 +533,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailCategoryBuilder& Roo
 					DetailBuilder->ForceRefreshDetails();
 				}
 
-				VitruvioActor->EvalRuleAttributes(VitruvioActor->GenerateAutomatically);
+				VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
 				Attribute->UserSet = true;
 			});
 			const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes = Generator->GetRootTreeNodes();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -65,7 +65,7 @@ template <typename A, typename V>
 void UpdateAttributeValue(UVitruvioComponent* VitruvioActor, A* Attribute, const V& Value)
 {
 	Attribute->Value = Value;
-	Attribute->UserSet = true;
+	Attribute->bUserSet = true;
 	VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
 }
 
@@ -262,7 +262,7 @@ TSharedPtr<SBox> CreateNameWidget(URuleAttribute* Attribute)
 		[
 			SNew(STextBlock)
 			.Text(FText::FromString(Attribute->DisplayName))
-			.Font(Attribute->UserSet ? IDetailLayoutBuilder::GetDetailFontBold() : IDetailLayoutBuilder::GetDetailFont())
+			.Font(Attribute->bUserSet ? IDetailLayoutBuilder::GetDetailFontBold() : IDetailLayoutBuilder::GetDetailFont())
 		];
 	// clang-format on
 	return NameWidget;
@@ -273,11 +273,11 @@ FResetToDefaultOverride ResetToDefaultOverride(URuleAttribute* Attribute, UVitru
 	FResetToDefaultOverride ResetToDefaultOverride = FResetToDefaultOverride::Create(
 	FIsResetToDefaultVisible::CreateLambda([Attribute](TSharedPtr<IPropertyHandle> Property)
 	{
-		return Attribute->UserSet;
+		return Attribute->bUserSet;
 	}),
 	FResetToDefaultHandler::CreateLambda([Attribute, VitruvioActor](TSharedPtr<IPropertyHandle> Property)
 	{
-		Attribute->UserSet = false;
+		Attribute->bUserSet = false;
 		VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
 	})
 	);
@@ -569,7 +569,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailLayoutBuilder& Detai
 	{
 		for (const auto& AttributeEntry : VitruvioActor->GetAttributes())
 		{
-			AttributeEntry.Value->UserSet = false;
+			AttributeEntry.Value->bUserSet = false;
 		}
 			
 		VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
@@ -608,7 +608,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailLayoutBuilder& Detai
 		Generator->SetObjects(Objects);
 		Generator->OnFinishedChangingProperties().AddLambda([this, VitruvioActor, Attribute](const FPropertyChangedEvent Event) {
 			VitruvioActor->EvaluateRuleAttributes(VitruvioActor->GenerateAutomatically);
-			Attribute->UserSet = true;
+			Attribute->bUserSet = true;
 		});
 		const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes = Generator->GetRootTreeNodes();
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -65,6 +65,7 @@ template <typename A, typename V>
 void UpdateAttributeValue(UVitruvioComponent* VitruvioActor, A* Attribute, const V& Value)
 {
 	Attribute->Value = Value;
+	Attribute->UserSet = true;
 	if (VitruvioActor->GenerateAutomatically)
 	{
 		VitruvioActor->Generate();
@@ -265,7 +266,7 @@ TSharedPtr<SBox> CreateNameWidget(URuleAttribute* Attribute)
 		[
 			SNew(STextBlock)
 			.Text(FText::FromString(Attribute->DisplayName))
-			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Font(Attribute->UserSet ? IDetailLayoutBuilder::GetDetailFontBold() : IDetailLayoutBuilder::GetDetailFont())
 		];
 	// clang-format on
 	return NameWidget;
@@ -528,7 +529,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailCategoryBuilder& Roo
 			TArray<UObject*> Objects;
 			Objects.Add(Attribute);
 			Generator->SetObjects(Objects);
-			Generator->OnFinishedChangingProperties().AddLambda([this, VitruvioActor](const FPropertyChangedEvent Event) {
+			Generator->OnFinishedChangingProperties().AddLambda([this, VitruvioActor, Attribute](const FPropertyChangedEvent Event) {
 				IDetailLayoutBuilder* DetailBuilder = CachedDetailBuilder.Pin().Get();
 				if (DetailBuilder)
 				{
@@ -539,6 +540,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailCategoryBuilder& Roo
 				{
 					VitruvioActor->Generate();
 				}
+				Attribute->UserSet = true;
 			});
 			const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes = Generator->GetRootTreeNodes();
 			

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -66,10 +66,7 @@ void UpdateAttributeValue(UVitruvioComponent* VitruvioActor, A* Attribute, const
 {
 	Attribute->Value = Value;
 	Attribute->UserSet = true;
-	if (VitruvioActor->GenerateAutomatically)
-	{
-		VitruvioActor->Generate();
-	}
+	VitruvioActor->EvalRuleAttributes(VitruvioActor->GenerateAutomatically);
 }
 
 bool IsVitruvioComponentSelected(const TArray<TWeakObjectPtr<UObject>>& ObjectsBeingCustomized, UVitruvioComponent*& OutComponent)
@@ -536,10 +533,7 @@ void FVitruvioComponentDetails::BuildAttributeEditor(IDetailCategoryBuilder& Roo
 					DetailBuilder->ForceRefreshDetails();
 				}
 
-				if (VitruvioActor->GenerateAutomatically)
-				{
-					VitruvioActor->Generate();
-				}
+				VitruvioActor->EvalRuleAttributes(VitruvioActor->GenerateAutomatically);
 				Attribute->UserSet = true;
 			});
 			const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes = Generator->GetRootTreeNodes();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -109,7 +109,14 @@ TSharedPtr<SPropertyComboBox<V>> CreateEnumWidget(Attr* Attribute, An* Annotatio
 	TArray<TSharedPtr<V>> SharedPtrValues;
 	Algo::Transform(Annotation->Values, SharedPtrValues, [](const V& Value) { return MakeShared<V>(Value); });
 	auto InitialSelectedIndex = Annotation->Values.IndexOfByPredicate([Attribute](const V& Value) { return Value == Attribute->Value; });
-	auto InitialSelectedValue = InitialSelectedIndex != INDEX_NONE ? SharedPtrValues[InitialSelectedIndex] : nullptr;
+	
+	// If the value is not present in the enum values we insert it at the beginning (similar behavior to CE inspector)
+	if (InitialSelectedIndex == INDEX_NONE) 
+	{
+		SharedPtrValues.Insert(MakeShared<V>(Attribute->Value), 0);
+		InitialSelectedIndex = 0;
+	}
+	auto InitialSelectedValue = SharedPtrValues[InitialSelectedIndex];
 
 	auto ValueWidget = SNew(SPropertyComboBox<V>)
 						   .ComboItemList(SharedPtrValues)

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -366,7 +366,7 @@ void AddArrayWidget(const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes, I
 					{
 						FString Value;
 						ColorStringProperty->GetValue(Value);
-						return FLinearColor(FColor::FromHex(Value));
+						return Value.IsEmpty() ? FLinearColor(1, 1, 1) : FLinearColor(FColor::FromHex(Value));
 					};
 					
 					ValueRow.ValueContent()[CreateColorInputWidget(ColorSetter, ColorGetter).ToSharedRef()];

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -149,7 +149,7 @@ TSharedPtr<SHorizontalBox> CreateColorInputWidget(TSharedPtr<IPropertyHandle> Co
 	{
 		FString Value;
 		ColorStringProperty->GetValue(Value);
-		return Value.IsEmpty() ? FLinearColor(1, 1, 1) : FLinearColor(FColor::FromHex(Value));
+		return Value.IsEmpty() ? FLinearColor::White : FLinearColor(FColor::FromHex(Value));
 	};
 	
 	// clang-format off

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -267,7 +267,7 @@ void VitruvioEditorModule::OnPostEngineInit()
 			if (VitruvioComponent && VitruvioComponent->GetRpk() == RulePackage)
 			{
 				VitruvioComponent->RemoveGeneratedMeshes();
-				VitruvioComponent->EvalRuleAttributes(true, true);
+				VitruvioComponent->EvalRuleAttributes(true);
 			}
 		}
 	});

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -267,7 +267,7 @@ void VitruvioEditorModule::OnPostEngineInit()
 			if (VitruvioComponent && VitruvioComponent->GetRpk() == RulePackage)
 			{
 				VitruvioComponent->RemoveGeneratedMeshes();
-				VitruvioComponent->EvalRuleAttributes(true);
+				VitruvioComponent->EvaluateRuleAttributes(true);
 			}
 		}
 	});

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -267,7 +267,7 @@ void VitruvioEditorModule::OnPostEngineInit()
 			if (VitruvioComponent && VitruvioComponent->GetRpk() == RulePackage)
 			{
 				VitruvioComponent->RemoveGeneratedMeshes();
-				VitruvioComponent->LoadDefaultAttributes(true, true);
+				VitruvioComponent->EvalRuleAttributes(true, true);
 			}
 		}
 	});

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
@@ -42,7 +42,7 @@ public:
 	void OnVitruvioComponentHierarchyChanged(UVitruvioComponent* Component);
 
 private:
-	void BuildAttributeEditor(IDetailCategoryBuilder& RootCategory, UVitruvioComponent* VitruvioActor);
+	void BuildAttributeEditor(IDetailLayoutBuilder& DetailBuilder, IDetailCategoryBuilder& RootCategory, UVitruvioComponent* VitruvioActor);
 
 	TArray<TWeakObjectPtr<UObject>> ObjectsBeingCustomized;
 	TWeakPtr<IDetailLayoutBuilder> CachedDetailBuilder;


### PR DESCRIPTION
#52 should be reviewed and merged first.

With this PR we want to add support of evaluating attributes before generation. This is needed for "dependent" attributes (eg if one attribute change results in another attribute value to change as well). To make this possible several small features have been added:

- Passing an existing set of attributes to re-evaluate the current attribute values
- A simplified concept of user set attributes. Eg if a user changes an attribute value it will not get overwritten when re-evaluating attributes
- Resetting attribute values via context menu (which removes their "user-set" status)