### PR TITLE
Bneukom/library fix

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/ThirdParty/PRT/PRT.Build.cs
+++ b/VitruvioHost/Plugins/Vitruvio/Source/ThirdParty/PRT/PRT.Build.cs
@@ -21,6 +21,8 @@ public class PRT : ModuleRules
 
 	private const string PrtCoreDllName = "com.esri.prt.core.dll";
 
+	private static readonly List<string> FilteredExtensionLibraries = new List<string>() { "DatasmithSDK.dll", "FreeImage317.dll", "com.esri.prt.unreal.dll" };
+
 	private const long ErrorSharingViolation = 0x20;
 	private const long ErrorLockViolation = 0x21;
 
@@ -93,7 +95,7 @@ public class PRT : ModuleRules
 
 				Directory.CreateDirectory(LibDir);
 				Directory.CreateDirectory(BinDir);
-				Copy(Path.Combine(ModuleDirectory, PrtLibName, "lib"), Path.Combine(ModuleDirectory, LibDir));
+				Copy(Path.Combine(ModuleDirectory, PrtLibName, "lib"), Path.Combine(ModuleDirectory, LibDir), FilteredExtensionLibraries);
 				Copy(Path.Combine(ModuleDirectory, PrtLibName, "bin"), Path.Combine(ModuleDirectory, BinDir));
 				Copy(Path.Combine(ModuleDirectory, PrtLibName, "include"), Path.Combine(ModuleDirectory, "include"));
 			}
@@ -167,13 +169,16 @@ public class PRT : ModuleRules
 		}
 	}
 
-	void Copy(string SrcDir, string DstDir)
+	void Copy(string SrcDir, string DstDir, List<string> Filter = null)
 	{
 		Directory.CreateDirectory(DstDir);
 
 		foreach (var CopyFile in Directory.GetFiles(SrcDir))
 		{
-			File.Copy(CopyFile, Path.Combine(DstDir, Path.GetFileName(CopyFile)));
+			if (Filter == null || !Filter.Contains(Path.GetFileName(CopyFile)))
+			{
+				File.Copy(CopyFile, Path.Combine(DstDir, Path.GetFileName(CopyFile)));
+			}
 		}
 
 		foreach (var Dir in Directory.GetDirectories(SrcDir))

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/RuleAttributes.h
@@ -172,7 +172,7 @@ class VITRUVIO_API UStringArrayAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Vitruvio")
 	TArray<FString> Values;
 
 	UStringEnumAnnotation* GetEnumAnnotation() const
@@ -230,7 +230,7 @@ class VITRUVIO_API UFloatArrayAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Vitruvio")
 	TArray<double> Values;
 
 	UFloatEnumAnnotation* GetEnumAnnotation() const
@@ -278,7 +278,7 @@ class VITRUVIO_API UBoolArrayAttribute final : public URuleAttribute
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Vitruvio")
 	TArray<bool> Values;
 
 	UColorAnnotation* GetColorAnnotation() const


### PR DESCRIPTION
#52 should be reviewed and merged first.

There was an issue with Datasmith imports when Vitruvio is enabled. The underlying issue is that the Datasmith encoder (from PRT) also loads FreeImage (as does Unreal) which led to issues because depending on which library was loaded first the Unreal Datasmith import would fail to load textures (the PRT Datasmith encoder FreeImage version is older).

We don't actually ever need the Datasmith encoder from PRT for Vitruvio so we can just filter it out when downloading PRT which fixes the issue.

Also added missing categories for BP editable fields which are necessary for Plugin packaging.