### PR TITLE
Bneukom/array fixes

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -335,9 +335,9 @@ void UVitruvioComponent::Initialize()
 	CalculateRandomSeed();
 
 	// Check if we can load the attributes and then generate (eg during play)
-	if (GenerateAutomatically && IsReadyToGenerate())
+	if (GenerateAutomatically && HasValidInputData())
 	{
-		Generate();
+		EvaluateRuleAttributes(true);
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -331,7 +331,7 @@ void AddSeparator(IDetailCategoryBuilder& RootCategory)
 template <typename A>
 TSharedPtr<SWidget> CreateFloatAttributeWidget(A* Attribute, const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	if (Attribute->GetEnumAnnotation())
+	if (Attribute->GetEnumAnnotation() && Attribute->GetEnumAnnotation()->Values.Num() > 0)
 	{
 		return CreateEnumWidget<double, UFloatEnumAnnotation>(Attribute->GetEnumAnnotation(), PropertyHandle).ToSharedRef();
 	}
@@ -344,7 +344,7 @@ TSharedPtr<SWidget> CreateFloatAttributeWidget(A* Attribute, const TSharedPtr<IP
 template <typename A>
 TSharedPtr<SWidget> CreateStringAttributeWidget(A* Attribute, const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	if (Attribute->GetEnumAnnotation())
+	if (Attribute->GetEnumAnnotation() && Attribute->GetEnumAnnotation()->Values.Num() > 0)
 	{
 		return CreateEnumWidget<FString, UStringEnumAnnotation>(Attribute->GetEnumAnnotation(), PropertyHandle);
 	}


### PR DESCRIPTION
Fixes rule evaluation problem when creating a VitruvioActor for the first time and disables enum widgets if the enum does not have any values.