### PR TITLE
Set up proper attribute recomputation for cooked meshes (#29)

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -224,6 +224,13 @@ UStaticMesh* SaveStaticMesh(UStaticMesh* Mesh, const FString& Path, FStaticMeshC
 	TArray<const FMeshDescription*> MeshDescriptions;
 	MeshDescriptions.Add(&NewMeshDescription);
 	PersistedMesh->BuildFromMeshDescriptions(MeshDescriptions);
+
+	check(PersistedMesh->GetNumSourceModels() == 1);
+	FStaticMeshSourceModel& SrcModel = PersistedMesh->GetSourceModel(0);
+	SrcModel.BuildSettings.bRecomputeNormals = false;
+	SrcModel.BuildSettings.bRecomputeTangents = false;
+	SrcModel.BuildSettings.bRemoveDegenerates = true;
+	
 	PersistedMesh->PostEditChange();
 	PersistedMesh->MarkPackageDirty();
 


### PR DESCRIPTION
PostEditChange will trigger a rebuild of the mesh and by default this will recompute normals/tangets which we do not want