### PR TITLE
log concurrency fix

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealLogHandler.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealLogHandler.cpp
@@ -19,6 +19,7 @@ DEFINE_LOG_CATEGORY(UnrealPrtLog)
 
 TArray<FLogMessage> UnrealLogHandler::PopMessages()
 {
+	FScopeLock Lock(&MessageLock);
 	TArray<FLogMessage> Result(Messages);
 	Messages.Empty();
 	return Result;
@@ -26,6 +27,7 @@ TArray<FLogMessage> UnrealLogHandler::PopMessages()
 
 void UnrealLogHandler::handleLogEvent(const wchar_t* msg, prt::LogLevel level)
 {
+	FScopeLock Lock(&MessageLock);
 	const FString MessageString(WCHAR_TO_TCHAR(msg));
 	Messages.Push({MessageString, level});
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/UnrealLogHandler.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/UnrealLogHandler.h
@@ -30,6 +30,7 @@ class UnrealLogHandler final : public prt::LogHandler
 {
 
 	TArray<FLogMessage> Messages;
+	FCriticalSection MessageLock;
 
 public:
 	UnrealLogHandler() = default;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -224,12 +224,19 @@ public:
 		return TextureCache;
 	}
 
-	DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnGenerateCompleted, int, int, int);
+	DECLARE_MULTICAST_DELEGATE_OneParam(FOnGenerateCompleted, int);
+
+	DECLARE_MULTICAST_DELEGATE_TwoParams(FOnAllGenerateCompleted, int, int);
 
 	/**
 	 * Delegate which is called after a generate call has completed.
 	 */
 	FOnGenerateCompleted OnGenerateCompleted;
+
+	/**
+	* Delegate which is called after all generate calls have completed.
+	*/
+	FOnAllGenerateCompleted OnAllGenerateCompleted;
 
 	void AddReferencedObjects(FReferenceCollector& Collector) override
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -219,7 +219,7 @@ void VitruvioEditorModule::StartupModule()
 	MenuExtenders.Add(LevelViewportContextMenuVitruvioExtender);
 	LevelViewportContextMenuVitruvioExtenderDelegateHandle = MenuExtenders.Last().GetHandle();
 
-	GenerateCompletedDelegateHandle = VitruvioModule::Get().OnGenerateCompleted.AddRaw(this, &VitruvioEditorModule::OnGenerateCompleted);
+	GenerateCompletedDelegateHandle = VitruvioModule::Get().OnAllGenerateCompleted.AddRaw(this, &VitruvioEditorModule::OnGenerateCompleted);
 
 	FCoreDelegates::OnPostEngineInit.AddRaw(this, &VitruvioEditorModule::OnPostEngineInit);
 
@@ -239,7 +239,7 @@ void VitruvioEditorModule::ShutdownModule()
 		});
 
 	FCoreDelegates::OnPostEngineInit.RemoveAll(this);
-	VitruvioModule::Get().OnGenerateCompleted.Remove(GenerateCompletedDelegateHandle);
+	VitruvioModule::Get().OnAllGenerateCompleted.Remove(GenerateCompletedDelegateHandle);
 	if (GEditor)
 	{
 		GEditor->GetEditorSubsystem<UImportSubsystem>()->OnAssetReimport.Remove(OnAssetReloadHandle);
@@ -282,13 +282,8 @@ void VitruvioEditorModule::OnMapChanged(UWorld* World, EMapChangeType ChangeType
 	}
 }
 
-void VitruvioEditorModule::OnGenerateCompleted(int GenerateCallsLeft, int NumWarnings, int NumErrors)
+void VitruvioEditorModule::OnGenerateCompleted(int NumWarnings, int NumErrors)
 {
-	if (GenerateCallsLeft > 0)
-	{
-		return;
-	}
-
 	FString NotificationText(TEXT("Generate Completed"));
 	const FSlateBrush* Image = nullptr;
 	if (NumErrors > 0)

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioEditorModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioEditorModule.h
@@ -26,7 +26,7 @@ public:
 private:
 	void OnPostEngineInit();
 	void OnMapChanged(UWorld* World, EMapChangeType ChangeType);
-	void OnGenerateCompleted(int GenerateCallsLeft, int NumWarnings, int NumErrors);
+	void OnGenerateCompleted(int NumWarnings, int NumErrors);
 	TWeakPtr<SNotificationItem> NotificationItem;
 
 	FDelegateHandle LevelViewportContextMenuVitruvioExtenderDelegateHandle;


### PR DESCRIPTION
The log handling was not locked properly which could lead to some rare crashes. Locked it properly and also only report warnings/errors after all generate calls have completed. It does not make sense to try to report warnings for individual generate calls due to the asynchronous nature of the generate process.