### PR TITLE
Fix FGCObject async construction

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/MeshCache.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/MeshCache.cpp
@@ -20,13 +20,8 @@ TSharedPtr<FVitruvioMesh> FMeshCache::InsertOrGet(const FString& Uri, const TSha
 	return Mesh;
 }
 
-void FMeshCache::Invalidate()
+void FMeshCache::Empty()
 {
 	FScopeLock Lock(&MeshCacheCriticalSection);
-	for (auto& Entry : Cache)
-	{
-		Entry.Value->Invalidate();
-	}
-
 	Cache.Empty();
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealCallbacks.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/UnrealCallbacks.cpp
@@ -171,10 +171,14 @@ void UnrealCallbacks::addMesh(const wchar_t* name, int32_t prototypeId, const wc
 
 	if (BaseVertexIndex > 0)
 	{
-		TSharedPtr<FVitruvioMesh> VitruvioMesh = MakeShared<FVitruvioMesh>(UriString, Description, MeshMaterials);
-		TSharedPtr<FVitruvioMesh> CachedMesh =
-			!UriString.IsEmpty() ? VitruvioModule::Get().GetMeshCache().InsertOrGet(UriString, VitruvioMesh) : VitruvioMesh;
-		Meshes.Add(prototypeId, CachedMesh);
+		TSharedPtr<FVitruvioMesh> Mesh = MakeShared<FVitruvioMesh>(UriString, Description, MeshMaterials);
+
+		if (!UriString.IsEmpty())
+		{
+			Mesh = VitruvioModule::Get().GetMeshCache().InsertOrGet(UriString, Mesh);
+		}
+		
+		Meshes.Add(prototypeId, Mesh);
 		Names.Add(prototypeId, NameString);
 	}
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioMesh.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioMesh.cpp
@@ -25,7 +25,7 @@ UMaterialInstanceDynamic* CacheMaterial(UMaterial* OpaqueParent, UMaterial* Mask
 
 FVitruvioMesh::~FVitruvioMesh()
 {
-	VitruvioModule* VitruvioModule = VitruvioModule::Get().GetUnchecked();
+	VitruvioModule* VitruvioModule = VitruvioModule::GetUnchecked();
 	if (StaticMesh && VitruvioModule)
 	{
 		VitruvioModule->UnregisterMesh(StaticMesh);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -393,6 +393,11 @@ FGenerateResultDescription VitruvioModule::Generate(const TArray<FInitialShapeFa
 
 	const int GenerateCalls = GenerateCallsCounter.Decrement();
 
+	if (!Initialized)
+	{
+		return {};
+	}
+
 	// Notify generate complete callback on game thread
 	AsyncTask(ENamedThreads::GameThread, [this, GenerateCalls]() {
 		OnGenerateCompleted.Broadcast(GenerateCalls);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -247,8 +247,8 @@ void VitruvioModule::InitializePrt()
 	PRTPluginsPaths.Add(const_cast<wchar_t*>(TCHAR_TO_WCHAR(*EncoderExtensionPath)));
 	PRTPluginsPaths.Add(const_cast<wchar_t*>(TCHAR_TO_WCHAR(*PrtExtensionPaths)));
 
-	LogHandler = new UnrealLogHandler;
-	prt::addLogHandler(LogHandler);
+	LogHandler = MakeUnique<UnrealLogHandler>();
+	prt::addLogHandler(LogHandler.Get());
 
 	prt::Status Status;
 	PrtLibrary = prt::init(PRTPluginsPaths.GetData(), PRTPluginsPaths.Num(), prt::LogLevel::LOG_TRACE, &Status);
@@ -304,8 +304,6 @@ void VitruvioModule::ShutdownModule()
 	CleanupTempRpkFolder();
 
 	UE_LOG(LogUnrealPrt, Display, TEXT("Shutdown complete"))
-
-	delete LogHandler;
 }
 
 Vitruvio::FTextureData VitruvioModule::DecodeTexture(UObject* Outer, const FString& Path, const FString& Key) const

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -487,6 +487,18 @@ void VitruvioModule::EvictFromResolveMapCache(URulePackage* RulePackage)
 	PrtCache->flushAll();
 }
 
+void VitruvioModule::RegisterMesh(UStaticMesh* StaticMesh)
+{
+	FScopeLock Lock(&RegisterMeshLock);
+	RegisteredMeshes.Add(StaticMesh);
+}
+
+void VitruvioModule::UnregisterMesh(UStaticMesh* StaticMesh)
+{
+	FScopeLock Lock(&RegisterMeshLock);
+	RegisteredMeshes.Remove(StaticMesh);
+}
+
 TFuture<ResolveMapSPtr> VitruvioModule::LoadResolveMapAsync(URulePackage* const RulePackage) const
 {
 	TPromise<ResolveMapSPtr> Promise;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/MeshCache.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/MeshCache.h
@@ -6,7 +6,7 @@ class FMeshCache
 public:
 	VITRUVIO_API TSharedPtr<FVitruvioMesh> Get(const FString& Uri);
 	VITRUVIO_API TSharedPtr<FVitruvioMesh> InsertOrGet(const FString& Uri, const TSharedPtr<FVitruvioMesh>& Mesh);
-	VITRUVIO_API void Invalidate();
+	VITRUVIO_API void Empty();
 
 private:
 	FCriticalSection MeshCacheCriticalSection;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioMesh.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioMesh.h
@@ -18,7 +18,7 @@ struct FCollisionData
 	}
 };
 
-class FVitruvioMesh : public FGCObject
+class FVitruvioMesh
 {
 	FString Uri;
 
@@ -35,8 +35,8 @@ public:
 	{
 	}
 
-	virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
-
+	~FVitruvioMesh();
+	
 	FString GetUri() const
 	{
 		return Uri;
@@ -56,8 +56,6 @@ public:
 	{
 		return CollisionData;
 	}
-
-	void Invalidate();
 
 	void Build(const FString& Name, TMap<Vitruvio::FMaterialAttributeContainer, UMaterialInstanceDynamic*>& MaterialCache,
 			   TMap<FString, Vitruvio::FTextureData>& TextureCache, UMaterial* OpaqueParent, UMaterial* MaskedParent, UMaterial* TranslucentParent);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -269,7 +269,7 @@ private:
 	prt::Object const* PrtLibrary = nullptr;
 	CacheObjectUPtr PrtCache;
 
-	UnrealLogHandler* LogHandler = nullptr;
+	TUniquePtr<UnrealLogHandler> LogHandler;
 
 	TAtomic<bool> Initialized = false;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -224,6 +224,16 @@ public:
 		return TextureCache;
 	}
 
+	/**
+	 * Registers a generated mesh to keep it from being garbage collected.
+	 */
+	VITRUVIO_API void RegisterMesh(UStaticMesh* StaticMesh);
+
+	/**
+	 * Unregisters a generated mesh and therefore allows the garbage collector to delete it if it not referenced anywhere else.
+	 */
+	VITRUVIO_API void UnregisterMesh(UStaticMesh* StaticMesh);
+
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnGenerateCompleted, int);
 
 	DECLARE_MULTICAST_DELEGATE_TwoParams(FOnAllGenerateCompleted, int, int);
@@ -241,11 +251,17 @@ public:
 	void AddReferencedObjects(FReferenceCollector& Collector) override
 	{
 		Collector.AddReferencedObjects(MaterialCache);
+		Collector.AddReferencedObjects(RegisteredMeshes);
 	};
 
 	static VitruvioModule& Get()
 	{
 		return FModuleManager::LoadModuleChecked<VitruvioModule>("Vitruvio");
+	}
+
+	static VitruvioModule* GetUnchecked()
+	{
+		return FModuleManager::LoadModulePtr<VitruvioModule>("Vitruvio");
 	}
 
 private:
@@ -270,7 +286,10 @@ private:
 
 	TMap<Vitruvio::FMaterialAttributeContainer, UMaterialInstanceDynamic*> MaterialCache;
 	TMap<FString, Vitruvio::FTextureData> TextureCache;
-	mutable FMeshCache MeshCache;
+	FMeshCache MeshCache;
+
+	FCriticalSection RegisterMeshLock;
+	TSet<UStaticMesh*> RegisteredMeshes;
 
 	TFuture<ResolveMapSPtr> LoadResolveMapAsync(URulePackage* RulePackage) const;
 	void InitializePrt();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -278,7 +278,7 @@ void VitruvioEditorModule::OnMapChanged(UWorld* World, EMapChangeType ChangeType
 {
 	if (ChangeType == EMapChangeType::TearDownWorld)
 	{
-		VitruvioModule::Get().GetMeshCache().Invalidate();
+		VitruvioModule::Get().GetMeshCache().Empty();
 	}
 }
 


### PR DESCRIPTION
Remove FGCObject from FVitruvioMesh because it is constructed in a background thread which can cause GC issues (if the GC runs at the same time the object is constructed). Instead we add it to a global list of used StaticMeshes in the VitruvioModule (and remove it once it is deconstructed). The VitruvioModule then handles the GC referenced objects.