### PR TITLE
Cknieling/concave initial shape

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -107,7 +107,7 @@ bool HasValidGeometry(const TArray<FInitialShapeFace>& InFaces)
 	return false;
 }
 
-TArray<FVector> GetInitialShapeFlippedUp(const bool bInitialShapeIsFlipped,const TArray<FVector>& Vertices)
+TArray<FVector> GetInitialShapeFlippedUp(const TArray<FVector>& Vertices)
 {
 	// Reverse vertices if first plane normal shows down
 	if (Vertices.Num() >= 3)
@@ -124,11 +124,6 @@ TArray<FVector> GetInitialShapeFlippedUp(const bool bInitialShapeIsFlipped,const
 
 		const FVector PlaneNormal(PlaneNormalOut.X, PlaneNormalOut.Y,PlaneNormalOut.Z);
 		float Dot = FVector::DotProduct(FVector::UpVector, PlaneNormal);
-
-		if (bInitialShapeIsFlipped)
-		{
-			Dot *= -1;
-		}
 		
 		if (Dot < 0)
 		{
@@ -194,13 +189,6 @@ void UInitialShape::Uninitialize()
 		VitruvioComponent = nullptr;
 	}
 }
-
-#if WITH_EDITOR
-bool UInitialShape::IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
-{
-	return PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(UVitruvioComponent, bFlipInitialShape);
-}
-#endif
 
 void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component)
 {
@@ -296,7 +284,7 @@ void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component)
 	TArray<FInitialShapeFace> InitialShapeFaces;
 	for (const TArray<FVector>& FaceVertices : Windings)
 	{
-		const TArray<FVector> FlippedVertices(GetInitialShapeFlippedUp(Component->bFlipInitialShape, FaceVertices));
+		const TArray<FVector> FlippedVertices(GetInitialShapeFlippedUp(FaceVertices));
 
 		InitialShapeFaces.Push(FInitialShapeFace{FlippedVertices});
 	}
@@ -366,11 +354,6 @@ bool USplineInitialShape::CanConstructFrom(AActor* Owner) const
 
 bool USplineInitialShape::IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
 {
-	if (Super::IsRelevantProperty(Object, PropertyChangedEvent))
-	{
-		return true;
-	}
-	
 	if (Object)
 	{
 		FProperty* Property = PropertyChangedEvent.Property;
@@ -382,11 +365,6 @@ bool USplineInitialShape::IsRelevantProperty(UObject* Object, const FPropertyCha
 
 bool UStaticMeshInitialShape::IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
 {
-	if (Super::IsRelevantProperty(Object, PropertyChangedEvent))
-	{
-		return true;
-	}
-
 	if (Object)
 	{
 		FProperty* Property = PropertyChangedEvent.Property;
@@ -459,7 +437,7 @@ void USplineInitialShape::Initialize(UVitruvioComponent* Component)
 		}
 	}
 
-	const TArray<FVector> FlippedVertices(GetInitialShapeFlippedUp(Component->bFlipInitialShape, Vertices));
+	const TArray<FVector> FlippedVertices(GetInitialShapeFlippedUp(Vertices));
 
 	SetFaces({FInitialShapeFace{FlippedVertices}});
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -95,7 +95,12 @@ public:
 	virtual void Uninitialize();
 
 #if WITH_EDITOR
-	virtual bool IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent);
+	virtual bool IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
+	{
+		unimplemented();
+		return false;
+	}
+
 #endif
 };
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -67,10 +67,6 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, DisplayName = "Generate Automatically", Category = "Vitruvio")
 	bool GenerateAutomatically = true;
 
-	/** Flip the direction geometry is generated from the initial shape. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, DisplayName = "Flip Initial Shape", Category = "Vitruvio")
-	bool bFlipInitialShape = false;
-	
 	/** Automatically hide initial shape after generation. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, DisplayName = "Hide Initial Shape after Generation", Category = "Vitruvio")
 	bool HideAfterGeneration = false;


### PR DESCRIPTION
Removed toggle to flip initial shapes. It is better to just rotate the whole Actor, since flipped initial shapes can often lead to unpredictable geometry.