### PR TITLE
Replace default spline with a simple square

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -446,8 +446,20 @@ void USplineInitialShape::Initialize(UVitruvioComponent* Component, const TArray
 {
 
 	AActor* Owner = Component->GetOwner();
+	
+	//create small default square footprint, if there is no startMesh
+	TArray<FInitialShapeFace> CurrInitialFaces = InitialFaces;
+	if (InitialFaces.Num() == 0)
+	{
+		FInitialShapeFace ShapeFace;
+		ShapeFace.Vertices.Add(FVector(1000,-1000,0));
+		ShapeFace.Vertices.Add(FVector(1000,1000,0));
+		ShapeFace.Vertices.Add(FVector(-1000,1000,0));
+		ShapeFace.Vertices.Add(FVector(-1000,-1000,0));
+		CurrInitialFaces.Add(ShapeFace);
+	}
 
-	for (const FInitialShapeFace& Face : InitialFaces)
+	for (const FInitialShapeFace& Face : CurrInitialFaces)
 	{
 		auto UniqueName = MakeUniqueObjectName(Owner, USplineComponent::StaticClass(), TEXT("InitialShapeSpline"));
 		USplineComponent* Spline = AttachComponent<USplineComponent>(Owner, UniqueName.ToString());


### PR DESCRIPTION
- Added a small square (20x20m) as a default shape when creating a spline on an empty VitruvioActor
- Since the default square uses linear nodes, duplicating those will also create linear nodes