### PR TITLE
Cknieling/default initial spline shape

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -271,6 +271,11 @@ UStaticMesh* CreateStaticMeshFromInitialFaces(const TArray<FInitialShapeFace>& I
 	return StaticMesh;
 }
 
+UStaticMesh* CreateDefaultStaticMesh()
+{
+	return CreateStaticMeshFromInitialFaces(CreateDefaultInitialFaces());
+}
+
 TArray<TArray<FSplinePoint>> CreateSplinePointsFromInitialFaces(const TArray<FInitialShapeFace>& InitialFaces)
 {
 	//create small default square footprint, if there is no startMesh
@@ -372,8 +377,8 @@ void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component)
 
 	if (StaticMesh == nullptr)
 	{
-		bIsValid = false;
-		return;
+		StaticMesh = CreateDefaultStaticMesh();
+		StaticMeshComponent->SetStaticMesh(StaticMesh);
 	}
 
 #if WITH_EDITORONLY_DATA


### PR DESCRIPTION
- Major refactor to separate all mesh conversions form Initialize function
- Added default static mesh if an empty VitruvioComponent is initialized