### PR TITLE
Cknieling/reuse default initial shape

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -262,7 +262,7 @@ bool IsCongruentToDefaultInitialShape(const TArray<FInitialShapeFace>& InitialFa
 				int32 IndexOffset = 0;
 				for (int32 CurrentIndex = 0; CurrentIndex < DefaultVertices.Num(); CurrentIndex++)
 				{
-					if (Vertices[(InitialIndexOffset + CurrentIndex) % Vertices.Num()] != DefaultVertices[CurrentIndex])
+					if (!Vertices[(InitialIndexOffset + CurrentIndex) % Vertices.Num()].Equals(DefaultVertices[CurrentIndex]))
 					{
 						bIsDefaultInitialShape = false;
 					}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -258,17 +258,16 @@ bool IsCongruentToDefaultInitialShape(const TArray<FInitialShapeFace>& InitialFa
 			int32 InitialIndexOffset;
 			if(Vertices.Find(FirstVertex,InitialIndexOffset))
 			{
-				bool bIsDefaultInitialShape = true;
 				int32 IndexOffset = 0;
 				for (int32 CurrentIndex = 0; CurrentIndex < DefaultVertices.Num(); CurrentIndex++)
 				{
 					if (!Vertices[(InitialIndexOffset + CurrentIndex) % Vertices.Num()].Equals(DefaultVertices[CurrentIndex]))
 					{
-						bIsDefaultInitialShape = false;
+						return false;
 					}
 					IndexOffset++;
 				}
-				return bIsDefaultInitialShape;
+				return true;
 			}
 		}
 	}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -262,7 +262,7 @@ bool IsCongruentToDefaultInitialShape(const TArray<FInitialShapeFace>& InitialFa
 				int32 IndexOffset = 0;
 				for (int32 CurrentIndex = 0; CurrentIndex < DefaultVertices.Num(); CurrentIndex++)
 				{
-					if (Vertices[(InitialIndexOffset + CurrentIndex) % DefaultVertices.Num()] != DefaultVertices[CurrentIndex])
+					if (Vertices[(InitialIndexOffset + CurrentIndex) % Vertices.Num()] != DefaultVertices[CurrentIndex])
 					{
 						bIsDefaultInitialShape = false;
 					}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -241,6 +241,40 @@ TArray<FInitialShapeFace> CreateDefaultInitialFaces()
 	return InitialFaces;
 }
 
+bool IsCongruentToDefaultInitialShape(const TArray<FInitialShapeFace>& InitialFaces)
+{
+	const TArray<FInitialShapeFace> DefaultInitialFaces = CreateDefaultInitialFaces();
+	check(DefaultInitialFaces.Num() == 1);
+	const TArray<FVector> DefaultVertices = DefaultInitialFaces[0].Vertices;
+	check(DefaultVertices.Num() == 4);
+
+	if (InitialFaces.Num() == DefaultInitialFaces.Num())
+	{
+		const TArray<FVector> Vertices = InitialFaces[0].Vertices;
+
+		if(Vertices.Num() == DefaultVertices.Num())
+		{
+			const FVector FirstVertex = DefaultVertices[0];
+			int32 InitialIndexOffset;
+			if(Vertices.Find(FirstVertex,InitialIndexOffset))
+			{
+				bool bIsDefaultInitialShape = true;
+				int32 IndexOffset = 0;
+				for (int32 CurrentIndex = 0; CurrentIndex < DefaultVertices.Num(); CurrentIndex++)
+				{
+					if (Vertices[(InitialIndexOffset + CurrentIndex) % DefaultVertices.Num()] != DefaultVertices[CurrentIndex])
+					{
+						bIsDefaultInitialShape = false;
+					}
+					IndexOffset++;
+				}
+				return bIsDefaultInitialShape;
+			}
+		}
+	}
+	return false;
+}
+
 UStaticMesh* CreateDefaultStaticMesh()
 {
 	UStaticMesh* StaticMesh;
@@ -288,6 +322,10 @@ UStaticMesh* CreateDefaultStaticMesh()
 
 UStaticMesh* CreateStaticMeshFromInitialFaces(const TArray<FInitialShapeFace>& InitialFaces)
 {
+	if(IsCongruentToDefaultInitialShape(InitialFaces))
+	{
+		return CreateDefaultStaticMesh();
+	}
 	TArray<FInitialShapeFace> CurrInitialFaces = InitialFaces;
 	if (InitialFaces.Num() == 0)
 	{


### PR DESCRIPTION
- Save default initial shape when created
- Reuse default initial shape instead of creating a new one, if already present
- Check if a mesh converted from a spline is congruent to the default mesh and reuse the default static mesh in that case