### PR TITLE
Always set the material indices of the collisionmesh

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelHISMComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelHISMComponent.h
@@ -34,6 +34,9 @@ class VITRUVIO_API UGeneratedModelHISMComponent : public UHierarchicalInstancedS
 		}
 
 		TriCollisionData->Indices = CollisionData.Indices;
+		TArray<uint16> MaterialIndices;
+		MaterialIndices.SetNumZeroed(CollisionData.Indices.Num());
+		TriCollisionData->MaterialIndices = MaterialIndices;
 		TriCollisionData->Vertices = CollisionData.Vertices;
 		TriCollisionData->bFlipNormals = true;
 		return true;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelStaticMeshComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelStaticMeshComponent.h
@@ -34,6 +34,9 @@ class VITRUVIO_API UGeneratedModelStaticMeshComponent : public UStaticMeshCompon
 		}
 
 		TriCollisionData->Indices = CollisionData.Indices;
+		TArray<uint16> MaterialIndices;
+		MaterialIndices.SetNumZeroed(CollisionData.Indices.Num());
+		TriCollisionData->MaterialIndices = MaterialIndices;
 		TriCollisionData->Vertices = CollisionData.Vertices;
 		TriCollisionData->bFlipNormals = true;
 		return true;


### PR DESCRIPTION
- Fix physX crash when colliding into a generated mesh that uses multiple materials
  - MaterialIndices (for the physical materials) have to be manually set before returning `TriCollisionData` in `GetPhysicsTriMeshData`
    - Otherwise these Indices are broken/wrong when additional (visual/shader) Materials are added to a mesh
  - currently setting all indices to 0 (default) seems to resolve this issue 