### PR TITLE
Bneukom/vitruvioactor crash fix

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -747,9 +747,11 @@ void UVitruvioComponent::SetInitialShapeType(const TSubclassOf<UInitialShape>& T
 
 void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate)
 {
-	check(Rpk);
-	check(InitialShape);
-
+	if (!HasValidInputData())
+	{
+		return;
+	}
+	
 	// Since we can not abort an ongoing generate call from PRT, we invalidate the result and evaluate the attributes again after the current request
 	// has completed.
 	if (EvalAttributesInvalidationToken)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -91,9 +91,10 @@ bool SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttr
 	}
 
 	TAttribute->Value = Value;
+	TAttribute->bUserSet = true;
 	if (VitruvioComponent->GenerateAutomatically && VitruvioComponent->IsReadyToGenerate())
 	{
-		VitruvioComponent->Generate();
+		VitruvioComponent->EvaluateRuleAttributes(true);
 	}
 
 	return true;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
@@ -20,7 +20,7 @@
 #include "VitruvioComponent.h"
 #include "VitruvioActor.generated.h"
 
-UCLASS()
+UCLASS(NotBlueprintable)
 class VITRUVIO_API AVitruvioActor : public AActor
 {
 	GENERATED_BODY()

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
@@ -28,7 +28,7 @@ class VITRUVIO_API AVitruvioActor : public AActor
 public:
 	AVitruvioActor();
 
-	UPROPERTY(VisibleAnywhere, Category = "Vitruvio")
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Vitruvio")
 	UVitruvioComponent* VitruvioComponent;
 
 	virtual void Tick(float DeltaSeconds) override;

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -255,10 +255,12 @@ void VitruvioEditorModule::OnPostEngineInit()
 	OnAssetReloadHandle = GEditor->GetEditorSubsystem<UImportSubsystem>()->OnAssetReimport.AddLambda([](UObject* Object)
 	{
 		URulePackage* RulePackage = Cast<URulePackage>(Object);
-		if (RulePackage)
+		if (!RulePackage)
 		{
-			VitruvioModule::Get().EvictFromResolveMapCache(RulePackage);
+			return;
 		}
+
+		VitruvioModule::Get().EvictFromResolveMapCache(RulePackage);
 
 		for (FActorIterator It(GEditor->GetEditorWorldContext().World()); It; ++It)
 		{

--- a/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
+++ b/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 2,
+	"Version": 3,
 	"VersionName": "2021.0 (CE SDK v2.4.7316)",
 	"FriendlyName": "Vitruvio",
 	"Description": "Vitruvio adds support for CityEngine's procedural runtime (PRT)",


### PR DESCRIPTION
- Fix crash when importing assets and having VitruvioActors without rules assigned
- Fix possible crashes when not saving initial shape static meshes and reopening the scene which references them