### PR TITLE
Cleanup: move check for static mesh into if

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioCooker.cpp
@@ -318,10 +318,8 @@ void CookVitruvioActors(TArray<AActor*> Actors)
 
 			// Persist Mesh
 			UGeneratedModelStaticMeshComponent* StaticMeshComponent = Actor->FindComponentByClass<UGeneratedModelStaticMeshComponent>();
-			if (StaticMeshComponent)
+			if (StaticMeshComponent && StaticMeshComponent->GetStaticMesh())
 			{
-				check(StaticMeshComponent->GetStaticMesh());
-
 				UStaticMesh* GeneratedMesh = StaticMeshComponent->GetStaticMesh();
 
 				UStaticMesh* PersistedMesh = SaveStaticMesh(GeneratedMesh, CookPath, MeshCache, MaterialCache, TextureCache);


### PR DESCRIPTION
Fix crash, when instanced objects don't have a static mesh parent