### PR TITLE
Switching cache type to Default

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -285,7 +285,7 @@ void VitruvioModule::InitializePrt()
 	PrtLibrary = prt::init(PRTPluginsPaths.GetData(), PRTPluginsPaths.Num(), prt::LogLevel::LOG_TRACE, &Status);
 	Initialized = Status == prt::STATUS_OK;
 
-	PrtCache.reset(prt::CacheObject::create(prt::CacheObject::CACHE_TYPE_NONREDUNDANT));
+	PrtCache.reset(prt::CacheObject::create(prt::CacheObject::CACHE_TYPE_DEFAULT));
 
 	const FString TempDir(WCHAR_TO_TCHAR(prtu::temp_directory_path().c_str()));
 	RpkFolder = FPaths::CreateTempFilename(*TempDir, TEXT("Vitruvio_"), TEXT(""));


### PR DESCRIPTION
- Switching cache type to Default
  - It seems there is a bug in PRT causing the non-redundant cache to fail when multiple image files with identical content are used in a rule file.