### PR TITLE
Revert PRT cache access locking

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -356,19 +356,13 @@ void VitruvioModule::ShutdownModule()
 
 Vitruvio::FTextureData VitruvioModule::DecodeTexture(UObject* Outer, const FString& Path, const FString& Key) const
 {
-	size_t BufferSize = 0;
-	std::unique_ptr<uint8_t[]> Buffer;
-	Vitruvio::FTextureMetadata TextureMetadata;
-	{
-		FScopeLock Lock(&PrtCacheLock);
-		const prt::AttributeMap* TextureMetadataAttributeMap = prt::createTextureMetadata(*Path, PrtCache.get());
-		TextureMetadata = Vitruvio::ParseTextureMetadata(TextureMetadataAttributeMap);
+	const prt::AttributeMap* TextureMetadataAttributeMap = prt::createTextureMetadata(*Path, PrtCache.get());
+	Vitruvio::FTextureMetadata TextureMetadata = Vitruvio::ParseTextureMetadata(TextureMetadataAttributeMap);
 
-		BufferSize = TextureMetadata.Width * TextureMetadata.Height * TextureMetadata.Bands * TextureMetadata.BytesPerBand;
-		Buffer = std::make_unique<uint8_t[]>(BufferSize);
+	size_t BufferSize = TextureMetadata.Width * TextureMetadata.Height * TextureMetadata.Bands * TextureMetadata.BytesPerBand;
+	auto Buffer = std::make_unique<uint8_t[]>(BufferSize);
 
-		prt::getTexturePixeldata(*Path, Buffer.get(), BufferSize, PrtCache.get());
-	}
+	prt::getTexturePixeldata(*Path, Buffer.get(), BufferSize, PrtCache.get());
 
 	return Vitruvio::DecodeTexture(Outer, Key, Path, TextureMetadata, std::move(Buffer), BufferSize);
 }
@@ -437,15 +431,12 @@ FGenerateResultDescription VitruvioModule::Generate(const FInitialShapePolygon& 
 
 	InitialShapeNOPtrVector Shapes = {Shape.get()};
 
-	{
-		FScopeLock Lock(&PrtCacheLock);
-		const prt::Status GenerateStatus = prt::generate(Shapes.data(), Shapes.size(), nullptr, EncoderIds.data(), EncoderIds.size(),
-														 EncoderOptions.data(), OutputHandler.Get(), PrtCache.get(), nullptr);
+	const prt::Status GenerateStatus = prt::generate(Shapes.data(), Shapes.size(), nullptr, EncoderIds.data(), EncoderIds.size(),
+													 EncoderOptions.data(), OutputHandler.Get(), PrtCache.get(), nullptr);
 
-		if (GenerateStatus != prt::STATUS_OK)
-		{
-			UE_LOG(LogUnrealPrt, Error, TEXT("PRT generate failed: %hs"), prt::getStatusDescription(GenerateStatus))
-		}
+	if (GenerateStatus != prt::STATUS_OK)
+	{
+		UE_LOG(LogUnrealPrt, Error, TEXT("PRT generate failed: %hs"), prt::getStatusDescription(GenerateStatus))
 	}
 
 	const int GenerateCalls = GenerateCallsCounter.Decrement();
@@ -517,7 +508,6 @@ FAttributeMapResult VitruvioModule::EvaluateRuleAttributesAsync(const FInitialSh
 		const RuleFileInfoUPtr StartRuleInfo(prt::createRuleFileInfo(RuleFileUri));
 		const std::wstring StartRule = prtu::detectStartRule(StartRuleInfo);
 
-		FScopeLock Lock(&PrtCacheLock);
 		prt::Status InfoStatus;
 		RuleFileInfoUPtr RuleInfo(prt::createRuleFileInfo(RuleFileUri, PrtCache.get(), &InfoStatus));
 		if (!RuleInfo || InfoStatus != prt::STATUS_OK)
@@ -550,7 +540,6 @@ void VitruvioModule::EvictFromResolveMapCache(URulePackage* RulePackage)
 {
 	const TLazyObjectPtr<URulePackage> LazyRulePackagePtr(RulePackage);
 	FScopeLock Lock(&LoadResolveMapLock);
-	FScopeLock CacheLock(&PrtCacheLock);
 	ResolveMapCache.Remove(LazyRulePackagePtr);
 	PrtCache->flushAll();
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -277,7 +277,6 @@ private:
 	void* PrtDllHandle = nullptr;
 	prt::Object const* PrtLibrary = nullptr;
 	CacheObjectUPtr PrtCache;
-	mutable FCriticalSection PrtCacheLock;
 
 	TUniquePtr<UnrealLogHandler> LogHandler;
 


### PR DESCRIPTION
Synchronizing the cache access is not necessary! The cache is already guaranteed to be synchronized via PRT. This change also practically made the generation process serial again.

The issues we tried to fix with the locking are most likely related to something else. I also can not reproduce them anymore even without the cache locking. It seems this was related to the preview versions of UE5 (I have encountered similar texture issues in other areas during the preview usage). If the issue appears again we should investigate again.