### PR TITLE
Add a category to the blueprintable UPROPERTY fields

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/Report.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/Report.h
@@ -37,12 +37,12 @@ USTRUCT(Blueprintable, DisplayName = "Vitruvio Report")
 struct VITRUVIO_API FReport {
 	GENERATED_USTRUCT_BODY();
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Vitruvio")
 	EReportPrimitiveType Type = EReportPrimitiveType::None;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Vitruvio")
 	FString Name;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Vitruvio")
 	FString Value;
 };


### PR DESCRIPTION
Fix build errors by adding a Category to the UPROPERTY fields