### PR TITLE
Bneukom/improve bp api

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -72,6 +72,30 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolAttribu
 	return Proxy;
 }
 
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																						 const TArray<double>& Values, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetFloatArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																						  const TArray<FString>& Values, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetStringArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																						const TArray<bool>& Values, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetBoolArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetAttributes(UVitruvioComponent* VitruvioComponent,
 																				const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting)
 {

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -162,13 +162,13 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitru
 
 	UGenerateCompletedCallbackProxy* InternalProxy = NewObject<UGenerateCompletedCallbackProxy>();
 	InternalProxy->RegisterWithGameInstance(WorldContextObject);
-	InternalProxy->OnGenerateCompletedCpp.AddLambda(FExecuteAfterCountdown(TotalActors, [Proxy]() {
+	InternalProxy->OnGenerateCompleted.AddLambda(FExecuteAfterCountdown(TotalActors, [Proxy]() {
+		Proxy->OnGenerateCompletedBlueprint.Broadcast();
 		Proxy->OnGenerateCompleted.Broadcast();
-		Proxy->OnGenerateCompletedCpp.Broadcast();
 	}));
-	InternalProxy->OnAttributesEvaluatedCpp.AddLambda(FExecuteAfterCountdown(TotalActors, [Proxy]() {
+	InternalProxy->OnAttributesEvaluated.AddLambda(FExecuteAfterCountdown(TotalActors, [Proxy]() {
+		Proxy->OnAttributesEvaluatedBlueprint.Broadcast();
 		Proxy->OnAttributesEvaluated.Broadcast();
-		Proxy->OnAttributesEvaluatedCpp.Broadcast();
 	}));
 
 	for (AActor* Actor : Actors)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -73,65 +73,65 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::Generate(UVitr
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					float Value, bool bAddIfNonExisting)
+																					float Value)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetFloatAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetFloatAttribute(Name, Value, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					 const FString& Value, bool bAddIfNonExisting)
+																					 const FString& Value)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetStringAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetStringAttribute(Name, Value, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																				   bool Value, bool bAddIfNonExisting)
+																				   bool Value)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetBoolAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetBoolAttribute(Name, Value, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						 const TArray<double>& Values, bool bAddIfNonExisting)
+																						 const TArray<double>& Values)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetFloatArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetFloatArrayAttribute(Name, Values, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						  const TArray<FString>& Values, bool bAddIfNonExisting)
+																						  const TArray<FString>& Values)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetStringArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetStringArrayAttribute(Name, Values, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						const TArray<bool>& Values, bool bAddIfNonExisting)
+																						const TArray<bool>& Values)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetBoolArrayAttribute(Name, Values, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetBoolArrayAttribute(Name, Values, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetAttributes(UVitruvioComponent* VitruvioComponent,
-																				const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting)
+																				const TMap<FString, FString>& NewAttributes)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetAttributes(NewAttributes, bAddIfNonExisting, Proxy);
+	VitruvioComponent->SetAttributes(NewAttributes, Proxy);
 	return Proxy;
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -21,17 +21,16 @@
 
 namespace
 {
-USceneComponent* CopyInitialShapeSceneComponent(AActor* OldActor, AActor* NewActor)
+void CopyInitialShapeSceneComponent(AActor* OldActor, AActor* NewActor)
 {
 	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
 	{
 		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
 		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(OldActor))
 		{
-			return DefaultInitialShape->CopySceneComponent(OldActor, NewActor);
+			DefaultInitialShape->CopySceneComponent(OldActor, NewActor);
 		}
 	}
-	return nullptr;
 }
 
 struct FExecuteAfterCountdown
@@ -189,8 +188,7 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitru
 		{
 			AVitruvioActor* VitruvioActor = Actor->GetWorld()->SpawnActor<AVitruvioActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
 
-			USceneComponent* NewInitialShapeSceneComponent = CopyInitialShapeSceneComponent(Actor, VitruvioActor);
-			NewInitialShapeSceneComponent->SetWorldTransform(VitruvioActor->GetTransform());
+			CopyInitialShapeSceneComponent(Actor, VitruvioActor);
 
 			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -191,8 +191,6 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitru
 			CopyInitialShapeSceneComponent(Actor, VitruvioActor);
 
 			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
-
-			VitruvioActor->Initialize();
 			VitruvioComponent->SetRpk(Rpk, bGenerateModels, InternalProxy);
 
 			if (OldAttachParent)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2021 Esri
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenerateCompletedCallbackProxy.h"
+
+#include "VitruvioBlueprintLibrary.h"
+#include "VitruvioComponent.h"
+
+namespace
+{
+USceneComponent* CopyInitialShapeSceneComponent(AActor* OldActor, AActor* NewActor)
+{
+	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
+	{
+		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
+		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(OldActor))
+		{
+			return DefaultInitialShape->CopySceneComponent(OldActor, NewActor);
+		}
+	}
+	return nullptr;
+}
+} // namespace
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetRpk(RulePackage, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::Generate(UVitruvioComponent* VitruvioComponent)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->Generate(Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																					float Value, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetFloatAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																					 const FString& Value, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetStringAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																				   bool Value, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetBoolAttribute(Name, Value, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetAttributes(UVitruvioComponent* VitruvioComponent,
+																				const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetAttributes(NewAttributes, bAddIfNonExisting, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetMeshInitialShape(StaticMesh, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetSplineInitialShape(UVitruvioComponent* VitruvioComponent,
+																						const TArray<FSplinePoint>& SplinePoints)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	VitruvioComponent->SetSplineInitialShape(SplinePoints, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitruvioActor(const TArray<AActor*>& Actors,
+																						 TArray<AVitruvioActor*>& OutVitruvioActors,
+																						 URulePackage* Rpk, bool bGenerateModels)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	for (AActor* Actor : Actors)
+	{
+		AActor* OldAttachParent = Actor->GetAttachParentActor();
+		if (UVitruvioBlueprintLibrary::CanConvertToVitruvioActor(Actor))
+		{
+			AVitruvioActor* VitruvioActor = Actor->GetWorld()->SpawnActor<AVitruvioActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
+
+			USceneComponent* NewInitialShapeSceneComponent = CopyInitialShapeSceneComponent(Actor, VitruvioActor);
+			NewInitialShapeSceneComponent->SetWorldTransform(VitruvioActor->GetTransform());
+
+			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
+
+			VitruvioActor->Initialize();
+
+			VitruvioComponent->GenerateAutomatically = bGenerateModels;
+			VitruvioComponent->SetRpk(Rpk, Proxy);
+
+			if (OldAttachParent)
+			{
+				VitruvioActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
+			}
+
+			Actor->Destroy();
+
+			// After constructing the VitruvioActor we always want to generate models automatically by default
+			VitruvioComponent->GenerateAutomatically = true;
+
+			OutVitruvioActors.Add(VitruvioActor);
+		}
+	}
+	return Proxy;
+}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -56,11 +56,21 @@ struct FExecuteAfterCountdown
 };
 } // namespace
 
-UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage)
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage,
+																		 bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetRpk(RulePackage, Proxy);
+	VitruvioComponent->SetRpk(RulePackage, bGenerateModel, Proxy);
+	return Proxy;
+}
+
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRandomSeed(UVitruvioComponent* VitruvioComponent, int32 NewRandomSeed,
+																				bool bGenerateModel)
+{
+	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
+	Proxy->RegisterWithGameInstance(VitruvioComponent);
+	VitruvioComponent->SetRandomSeed(NewRandomSeed, bGenerateModel, Proxy);
 	return Proxy;
 }
 
@@ -73,82 +83,83 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::Generate(UVitr
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					float Value)
+																					float Value, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetFloatAttribute(Name, Value, Proxy);
+	VitruvioComponent->SetFloatAttribute(Name, Value, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					 const FString& Value)
+																					 const FString& Value, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetStringAttribute(Name, Value, Proxy);
+	VitruvioComponent->SetStringAttribute(Name, Value, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																				   bool Value)
+																				   bool Value, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetBoolAttribute(Name, Value, Proxy);
+	VitruvioComponent->SetBoolAttribute(Name, Value, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						 const TArray<double>& Values)
+																						 const TArray<double>& Values, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetFloatArrayAttribute(Name, Values, Proxy);
+	VitruvioComponent->SetFloatArrayAttribute(Name, Values, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						  const TArray<FString>& Values)
+																						  const TArray<FString>& Values, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetStringArrayAttribute(Name, Values, Proxy);
+	VitruvioComponent->SetStringArrayAttribute(Name, Values, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						const TArray<bool>& Values)
+																						const TArray<bool>& Values, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetBoolArrayAttribute(Name, Values, Proxy);
+	VitruvioComponent->SetBoolArrayAttribute(Name, Values, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetAttributes(UVitruvioComponent* VitruvioComponent,
-																				const TMap<FString, FString>& NewAttributes)
+																				const TMap<FString, FString>& NewAttributes, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetAttributes(NewAttributes, Proxy);
+	VitruvioComponent->SetAttributes(NewAttributes, bGenerateModel, Proxy);
 	return Proxy;
 }
 
-UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh)
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh,
+																					  bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetMeshInitialShape(StaticMesh, Proxy);
+	VitruvioComponent->SetMeshInitialShape(StaticMesh, bGenerateModel, Proxy);
 	return Proxy;
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetSplineInitialShape(UVitruvioComponent* VitruvioComponent,
-																						const TArray<FSplinePoint>& SplinePoints)
+																						const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(VitruvioComponent);
-	VitruvioComponent->SetSplineInitialShape(SplinePoints, Proxy);
+	VitruvioComponent->SetSplineInitialShape(SplinePoints, bGenerateModel, Proxy);
 	return Proxy;
 }
 
@@ -184,9 +195,7 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitru
 			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
 
 			VitruvioActor->Initialize();
-
-			VitruvioComponent->GenerateAutomatically = bGenerateModels;
-			VitruvioComponent->SetRpk(Rpk, InternalProxy);
+			VitruvioComponent->SetRpk(Rpk, bGenerateModels, InternalProxy);
 
 			if (OldAttachParent)
 			{
@@ -194,9 +203,6 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitru
 			}
 
 			Actor->Destroy();
-
-			// After constructing the VitruvioActor we always want to generate models automatically by default
-			VitruvioComponent->GenerateAutomatically = true;
 
 			OutVitruvioActors.Add(VitruvioActor);
 		}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -512,6 +512,14 @@ bool UStaticMeshInitialShape::CanConstructFrom(AActor* Owner) const
 	return false;
 }
 
+USceneComponent* UStaticMeshInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
+{
+	const UStaticMeshComponent* OldStaticMeshComponent = OldActor->FindComponentByClass<UStaticMeshComponent>();
+	UStaticMeshComponent* NewStaticMeshComponent = AttachComponent<UStaticMeshComponent>(NewActor, TEXT("InitialShapeSpline"));
+	NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
+	return NewStaticMeshComponent;
+}
+
 void UStaticMeshInitialShape::SetHidden(bool bHidden)
 {
 	InitialShapeSceneComponent->SetVisibility(!bHidden, false);
@@ -526,6 +534,15 @@ bool USplineInitialShape::CanConstructFrom(AActor* Owner) const
 		return SplineComponent != nullptr && SplineComponent->GetNumberOfSplinePoints() > 0;
 	}
 	return false;
+}
+
+USceneComponent* USplineInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
+{
+	const USplineComponent* OldSplineComponent = OldActor->FindComponentByClass<USplineComponent>();
+	USplineComponent* NewSplineComponent = AttachComponent<USplineComponent>(NewActor, TEXT("InitialShapeStaticMesh"));
+	NewSplineComponent->SetClosedLoop(true);
+	NewSplineComponent->SplineCurves = OldSplineComponent->SplineCurves;
+	return NewSplineComponent;
 }
 #if WITH_EDITOR
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -25,12 +25,15 @@
 namespace
 {
 template <typename T>
-T* AttachComponent(AActor* Owner, const FString& Name)
+T* AttachComponent(AActor* Owner, const FString& Name, bool bAttachToRoot = true)
 {
 	T* Component = NewObject<T>(Owner, *Name, RF_Transactional);
 	Component->Mobility = EComponentMobility::Movable;
 	Owner->AddInstanceComponent(Component);
-	Component->AttachToComponent(Owner->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+	if (bAttachToRoot)
+	{
+		Component->AttachToComponent(Owner->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+	}
 	Component->OnComponentCreated();
 	Component->RegisterComponent();
 	return Component;
@@ -515,13 +518,13 @@ bool UStaticMeshInitialShape::CanConstructFrom(AActor* Owner) const
 USceneComponent* UStaticMeshInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
 {
 	const UStaticMeshComponent* OldStaticMeshComponent = OldActor->FindComponentByClass<UStaticMeshComponent>();
-	UStaticMeshComponent* NewStaticMeshComponent = AttachComponent<UStaticMeshComponent>(NewActor, TEXT("InitialShapeSpline"));
+	UStaticMeshComponent* NewStaticMeshComponent = AttachComponent<UStaticMeshComponent>(NewActor, TEXT("InitialShapeStaticMesh"), false);
 	if (OldStaticMeshComponent)
 	{
 		NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
 		NewStaticMeshComponent->SetWorldTransform(OldStaticMeshComponent->GetComponentTransform());
-		NewActor->SetRootComponent(NewStaticMeshComponent);
 	}
+	NewActor->SetRootComponent(NewStaticMeshComponent);
 	return NewStaticMeshComponent;
 }
 
@@ -544,14 +547,14 @@ bool USplineInitialShape::CanConstructFrom(AActor* Owner) const
 USceneComponent* USplineInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
 {
 	const USplineComponent* OldSplineComponent = OldActor->FindComponentByClass<USplineComponent>();
-	USplineComponent* NewSplineComponent = AttachComponent<USplineComponent>(NewActor, TEXT("InitialShapeStaticMesh"));
+	USplineComponent* NewSplineComponent = AttachComponent<USplineComponent>(NewActor, TEXT("InitialShapeSpline"), false);
 	NewSplineComponent->SetClosedLoop(true);
 	if (OldSplineComponent)
 	{
 		NewSplineComponent->SplineCurves = OldSplineComponent->SplineCurves;
 		NewSplineComponent->SetWorldTransform(OldSplineComponent->GetComponentTransform());
-		NewActor->SetRootComponent(NewSplineComponent);
 	}
+	NewActor->SetRootComponent(NewSplineComponent);
 	return NewSplineComponent;
 }
 #if WITH_EDITOR

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -516,7 +516,10 @@ USceneComponent* UStaticMeshInitialShape::CopySceneComponent(AActor* OldActor, A
 {
 	const UStaticMeshComponent* OldStaticMeshComponent = OldActor->FindComponentByClass<UStaticMeshComponent>();
 	UStaticMeshComponent* NewStaticMeshComponent = AttachComponent<UStaticMeshComponent>(NewActor, TEXT("InitialShapeSpline"));
-	NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
+	if (OldStaticMeshComponent)
+	{
+		NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
+	}
 	return NewStaticMeshComponent;
 }
 
@@ -541,7 +544,10 @@ USceneComponent* USplineInitialShape::CopySceneComponent(AActor* OldActor, AActo
 	const USplineComponent* OldSplineComponent = OldActor->FindComponentByClass<USplineComponent>();
 	USplineComponent* NewSplineComponent = AttachComponent<USplineComponent>(NewActor, TEXT("InitialShapeStaticMesh"));
 	NewSplineComponent->SetClosedLoop(true);
-	NewSplineComponent->SplineCurves = OldSplineComponent->SplineCurves;
+	if (OldSplineComponent)
+	{
+		NewSplineComponent->SplineCurves = OldSplineComponent->SplineCurves;
+	}
 	return NewSplineComponent;
 }
 #if WITH_EDITOR

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -485,13 +485,16 @@ void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component)
 
 void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon)
 {
+	Initialize(Component, CreateStaticMeshFromInitialShapePolygon(InitialShapePolygon));
+}
+
+void UStaticMeshInitialShape::Initialize(UVitruvioComponent* Component, UStaticMesh* StaticMesh)
+{
 	AActor* Owner = Component->GetOwner();
 	if (!Owner)
 	{
 		return;
 	}
-
-	UStaticMesh* StaticMesh = CreateStaticMeshFromInitialShapePolygon(InitialShapePolygon);
 
 	UStaticMeshComponent* AttachedStaticMeshComponent = AttachComponent<UStaticMeshComponent>(Owner, TEXT("InitialShapeStaticMesh"));
 	AttachedStaticMeshComponent->SetStaticMesh(StaticMesh);
@@ -608,13 +611,17 @@ void USplineInitialShape::Initialize(UVitruvioComponent* Component)
 
 void USplineInitialShape::Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon)
 {
+	Initialize(Component, CreateSplinePointsFromInitialShapePolygon(InitialShapePolygon));
+}
+
+void USplineInitialShape::Initialize(UVitruvioComponent* Component, const TArray<FSplinePoint>& SplinePoints)
+{
 	AActor* Owner = Component->GetOwner();
 	if (!Owner)
 	{
 		return;
 	}
 
-	TArray<FSplinePoint> SplinePoints = CreateSplinePointsFromInitialShapePolygon(InitialShapePolygon);
 	const auto UniqueName = MakeUniqueObjectName(Owner, USplineComponent::StaticClass(), TEXT("InitialShapeSpline"));
 	USplineComponent* Spline = AttachComponent<USplineComponent>(Owner, UniqueName.ToString());
 	Spline->ClearSplinePoints(true);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -519,6 +519,8 @@ USceneComponent* UStaticMeshInitialShape::CopySceneComponent(AActor* OldActor, A
 	if (OldStaticMeshComponent)
 	{
 		NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
+		NewStaticMeshComponent->SetWorldTransform(OldStaticMeshComponent->GetComponentTransform());
+		NewActor->SetRootComponent(NewStaticMeshComponent);
 	}
 	return NewStaticMeshComponent;
 }
@@ -547,6 +549,8 @@ USceneComponent* USplineInitialShape::CopySceneComponent(AActor* OldActor, AActo
 	if (OldSplineComponent)
 	{
 		NewSplineComponent->SplineCurves = OldSplineComponent->SplineCurves;
+		NewSplineComponent->SetWorldTransform(OldSplineComponent->GetComponentTransform());
+		NewActor->SetRootComponent(NewSplineComponent);
 	}
 	return NewSplineComponent;
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioActor.cpp
@@ -42,6 +42,7 @@ void AVitruvioActor::Initialize()
 	if (!bInitialized)
 	{
 		VitruvioComponent->Initialize();
+		VitruvioComponent->EvaluateRuleAttributes(VitruvioComponent->GenerateAutomatically);
 		bInitialized = true;
 	}
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioActor.cpp
@@ -21,28 +21,4 @@ AVitruvioActor::AVitruvioActor()
 {
 	RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
 	VitruvioComponent = CreateDefaultSubobject<UVitruvioComponent>(TEXT("VitruvioComponent"));
-	PrimaryActorTick.bCanEverTick = true;
-}
-
-void AVitruvioActor::Tick(float DeltaSeconds)
-{
-	// We do the initialization late here because we need all Components loaded and copy/pasted
-	// In PostCreated we can not differentiate between an Actor which has been copy pasted
-	// (in which case we would not need to load the initial shape) or spawned normally
-	Initialize();
-}
-
-bool AVitruvioActor::ShouldTickIfViewportsOnly() const
-{
-	return true;
-}
-
-void AVitruvioActor::Initialize()
-{
-	if (!bInitialized)
-	{
-		VitruvioComponent->Initialize();
-		VitruvioComponent->EvaluateRuleAttributes(VitruvioComponent->GenerateAutomatically);
-		bInitialized = true;
-	}
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
@@ -43,7 +43,7 @@ TArray<AActor*> UVitruvioBlueprintLibrary::GetViableVitruvioActorsInHierarchy(AA
 
 bool UVitruvioBlueprintLibrary::CanConvertToVitruvioActor(AActor* Actor)
 {
-	if (Cast<AVitruvioActor>(Actor))
+	if (!Actor || Cast<AVitruvioActor>(Actor))
 	{
 		return false;
 	}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
@@ -18,22 +18,6 @@
 #include "Engine/StaticMeshActor.h"
 #include "VitruvioActor.h"
 
-namespace
-{
-USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor)
-{
-	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
-	{
-		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
-		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(OldActor))
-		{
-			return DefaultInitialShape->CopySceneComponent(OldActor, NewActor);
-		}
-	}
-	return nullptr;
-}
-} // namespace
-
 TArray<AActor*> UVitruvioBlueprintLibrary::GetViableVitruvioActorsInHierarchy(AActor* Root)
 {
 	TArray<AActor*> ViableActors;
@@ -55,37 +39,6 @@ TArray<AActor*> UVitruvioBlueprintLibrary::GetViableVitruvioActorsInHierarchy(AA
 	}
 
 	return ViableActors;
-}
-
-TArray<AVitruvioActor*> UVitruvioBlueprintLibrary::ConvertToVitruvioActor(const TArray<AActor*>& Actors, URulePackage* Rpk)
-{
-	TArray<AVitruvioActor*> ConvertedActors;
-	for (AActor* Actor : Actors)
-	{
-		AActor* OldAttachParent = Actor->GetAttachParentActor();
-		if (CanConvertToVitruvioActor(Actor))
-		{
-			AVitruvioActor* VitruvioActor = Actor->GetWorld()->SpawnActor<AVitruvioActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
-
-			USceneComponent* NewInitialShapeSceneComponent = CopySceneComponent(Actor, VitruvioActor);
-			NewInitialShapeSceneComponent->SetWorldTransform(VitruvioActor->GetTransform());
-
-			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
-			VitruvioComponent->SetRpk(Rpk);
-
-			VitruvioActor->Initialize();
-
-			if (OldAttachParent)
-			{
-				VitruvioActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
-			}
-
-			Actor->Destroy();
-
-			ConvertedActors.Add(VitruvioActor);
-		}
-	}
-	return ConvertedActors;
 }
 
 bool UVitruvioBlueprintLibrary::CanConvertToVitruvioActor(AActor* Actor)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBlueprintLibrary.cpp
@@ -1,0 +1,113 @@
+/* Copyright 2021 Esri
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VitruvioBlueprintLibrary.h"
+
+#include "Engine/StaticMeshActor.h"
+#include "VitruvioActor.h"
+
+namespace
+{
+USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor)
+{
+	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
+	{
+		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
+		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(OldActor))
+		{
+			return DefaultInitialShape->CopySceneComponent(OldActor, NewActor);
+		}
+	}
+	return nullptr;
+}
+} // namespace
+
+TArray<AActor*> UVitruvioBlueprintLibrary::GetViableVitruvioActorsInHierarchy(AActor* Root)
+{
+	TArray<AActor*> ViableActors;
+	if (CanConvertToVitruvioActor(Root))
+	{
+		ViableActors.Add(Root);
+	}
+
+	// If the actor has a VitruvioComponent attached we do not further check its children.
+	if (Root->FindComponentByClass<UVitruvioComponent>() == nullptr)
+	{
+		TArray<AActor*> ChildActors;
+		Root->GetAttachedActors(ChildActors);
+
+		for (AActor* Child : ChildActors)
+		{
+			ViableActors.Append(GetViableVitruvioActorsInHierarchy(Child));
+		}
+	}
+
+	return ViableActors;
+}
+
+TArray<AVitruvioActor*> UVitruvioBlueprintLibrary::ConvertToVitruvioActor(const TArray<AActor*>& Actors, URulePackage* Rpk)
+{
+	TArray<AVitruvioActor*> ConvertedActors;
+	for (AActor* Actor : Actors)
+	{
+		AActor* OldAttachParent = Actor->GetAttachParentActor();
+		if (CanConvertToVitruvioActor(Actor))
+		{
+			AVitruvioActor* VitruvioActor = Actor->GetWorld()->SpawnActor<AVitruvioActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
+
+			USceneComponent* NewInitialShapeSceneComponent = CopySceneComponent(Actor, VitruvioActor);
+			NewInitialShapeSceneComponent->SetWorldTransform(VitruvioActor->GetTransform());
+
+			UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
+			VitruvioComponent->SetRpk(Rpk);
+
+			VitruvioActor->Initialize();
+
+			if (OldAttachParent)
+			{
+				VitruvioActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
+			}
+
+			Actor->Destroy();
+
+			ConvertedActors.Add(VitruvioActor);
+		}
+	}
+	return ConvertedActors;
+}
+
+bool UVitruvioBlueprintLibrary::CanConvertToVitruvioActor(AActor* Actor)
+{
+	if (Cast<AVitruvioActor>(Actor))
+	{
+		return false;
+	}
+
+	if (Actor->GetComponentByClass(UVitruvioComponent::StaticClass()))
+	{
+		return false;
+	}
+
+	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
+	{
+		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
+		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(Actor))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -234,6 +234,11 @@ void UVitruvioComponent::SetRpk(URulePackage* RulePackage)
 	Attributes.Empty();
 	bAttributesReady = false;
 	bNotifyAttributeChange = true;
+
+	if (GenerateAutomatically)
+	{
+		EvaluateRuleAttributes(true);
+	}
 }
 
 bool UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -176,17 +176,25 @@ void EvaluateAndSetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<
 			const FString& Value = KeyValues.Value;
 			const FString& Key = KeyValues.Key;
 
-			if (FCString::IsNumeric(*Value))
+			URuleAttribute* const* AttributeResult = VitruvioComponent->GetAttributes().Find(Key);
+			if (!AttributeResult)
+			{
+				continue;
+			}
+
+			URuleAttribute const* Attribute = *AttributeResult;
+
+			if (Cast<UFloatAttribute>(Attribute))
 			{
 				SetAttribute<UFloatAttribute, double>(VitruvioComponent, VitruvioComponent->GetAttributes(), Key, FCString::Atof(*Value), false,
 													  false, CallbackProxy);
 			}
-			else if (Value == "true" || Value == "false")
+			else if (Cast<UBoolAttribute>(Attribute))
 			{
-				SetAttribute<UBoolAttribute, bool>(VitruvioComponent, VitruvioComponent->GetAttributes(), Key, Value == "true", false, false,
-												   CallbackProxy);
+				SetAttribute<UBoolAttribute, bool>(VitruvioComponent, VitruvioComponent->GetAttributes(), Key, Value == "true" || Value == "1", false,
+												   false, CallbackProxy);
 			}
-			else
+			else if (Cast<UStringAttribute>(Attribute))
 			{
 				SetAttribute<UStringAttribute, FString>(VitruvioComponent, VitruvioComponent->GetAttributes(), Key, Value, false, false,
 														CallbackProxy);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -387,7 +387,8 @@ void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh, UGenerateC
 	SetInitialShape(this, CallbackProxy, [this, StaticMesh]()
 	{
 		UStaticMeshInitialShape* NewInitialShape =
-		NewObject<UStaticMeshInitialShape>(GetOwner(), UStaticMeshInitialShape::StaticClass(), NAME_None, RF_Transient | RF_TextExportTransient);
+		NewObject<UStaticMeshInitialShape>(GetOwner(), UStaticMeshInitialShape::StaticClass(),
+			NAME_None, RF_Transient | RF_TextExportTransient | RF_Transactional);
 		NewInitialShape->Initialize(this, StaticMesh);
 		return NewInitialShape;
 	});
@@ -398,7 +399,8 @@ void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& Splin
 	SetInitialShape(this, CallbackProxy, [this, &SplinePoints]()
 	{
 		USplineInitialShape* NewInitialShape =
-		NewObject<USplineInitialShape>(GetOwner(), USplineInitialShape::StaticClass(), NAME_None, RF_Transient | RF_TextExportTransient);
+		NewObject<USplineInitialShape>(GetOwner(), USplineInitialShape::StaticClass(),
+			NAME_None, RF_Transient | RF_TextExportTransient | RF_Transactional);
 		NewInitialShape->Initialize(this, SplinePoints);
 		return NewInitialShape;
 	});

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -432,7 +432,7 @@ void UVitruvioComponent::LoadInitialShape()
 	// If the initial shape has already been set just make sure it is valid
 	if (InitialShape)
 	{
-		if(!IsValid(InitialShape->GetComponent()))
+		if (!IsValid(InitialShape->GetComponent()))
 		{
 			InitialShape->Initialize(this);
 		}
@@ -614,8 +614,8 @@ void UVitruvioComponent::ProcessGenerateQueue()
 
 		if (Result.CallbackProxy)
 		{
+			Result.CallbackProxy->OnGenerateCompletedBlueprint.Broadcast();
 			Result.CallbackProxy->OnGenerateCompleted.Broadcast();
-			Result.CallbackProxy->OnGenerateCompletedCpp.Broadcast();
 			Result.CallbackProxy->SetReadyToDestroy();
 		}
 		OnGenerateCompleted.Broadcast();
@@ -636,8 +636,8 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 
 		if (AttributesEvaluation.CallbackProxy)
 		{
+			AttributesEvaluation.CallbackProxy->OnAttributesEvaluatedBlueprint.Broadcast();
 			AttributesEvaluation.CallbackProxy->OnAttributesEvaluated.Broadcast();
-			AttributesEvaluation.CallbackProxy->OnAttributesEvaluatedCpp.Broadcast();
 		}
 		OnAttributesEvaluated.Broadcast();
 
@@ -648,7 +648,7 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 		else if (AttributesEvaluation.CallbackProxy)
 		{
 			AttributesEvaluation.CallbackProxy->SetReadyToDestroy();
-		} 
+		}
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -108,10 +108,7 @@ void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttr
 
 	TAttribute->Value = Value;
 	TAttribute->bUserSet = true;
-	if (VitruvioComponent->GenerateAutomatically)
-	{
-		VitruvioComponent->EvaluateRuleAttributes(true);
-	}
+	VitruvioComponent->EvaluateRuleAttributes(VitruvioComponent->GenerateAutomatically, CallbackProxy);
 }
 
 bool IsOuterOf(UObject* Inner, UObject* Outer)
@@ -249,10 +246,8 @@ void UVitruvioComponent::SetRpk(URulePackage* RulePackage, UGenerateCompletedCal
 	bAttributesReady = false;
 	bNotifyAttributeChange = true;
 
-	if (GenerateAutomatically)
-	{
-		EvaluateRuleAttributes(true);
-	}
+	RemoveGeneratedMeshes();
+	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 
 void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting,
@@ -312,9 +307,9 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 	}
 
 	GenerateAutomatically = bOldGenerateAutomatically;
-	if (GenerateAutomatically && HasValidInputData())
+	if (HasValidInputData())
 	{
-		EvaluateRuleAttributes(true);
+		EvaluateRuleAttributes(GenerateAutomatically);
 	}
 }
 
@@ -332,10 +327,7 @@ void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh, UGenerateC
 
 	InitialShape = NewInitialShape;
 
-	if (GenerateAutomatically)
-	{
-		EvaluateRuleAttributes(true);
-	}
+	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 
 void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, UGenerateCompletedCallbackProxy* CallbackProxy)
@@ -352,10 +344,7 @@ void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& Splin
 
 	InitialShape = NewInitialShape;
 
-	if (GenerateAutomatically)
-	{
-		EvaluateRuleAttributes(true);
-	}
+	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 
 const TMap<FString, URuleAttribute*>& UVitruvioComponent::GetAttributes() const
@@ -838,8 +827,7 @@ void UVitruvioComponent::OnPropertyChanged(UObject* Object, FPropertyChangedEven
 
 	if (HasValidInputData() && (!bAttributesReady || bIsAttributeUndo))
 	{
-		// Force regeneration on attribute undo
-		EvaluateRuleAttributes(bIsAttributeUndo);
+		EvaluateRuleAttributes(true);
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -294,15 +294,15 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 
 		if (FCString::IsNumeric(*Value))
 		{
-			SetFloatAttribute(Key, FCString::Atof(*Value), bAddIfNonExisting);
+			SetFloatAttribute(Key, FCString::Atof(*Value), bAddIfNonExisting, CallbackProxy);
 		}
 		else if (Value == "true" || Value == "false")
 		{
-			SetBoolAttribute(Key, Value == "true", bAddIfNonExisting);
+			SetBoolAttribute(Key, Value == "true", bAddIfNonExisting, CallbackProxy);
 		}
 		else
 		{
-			SetStringAttribute(Key, Value, bAddIfNonExisting);
+			SetStringAttribute(Key, Value, bAddIfNonExisting, CallbackProxy);
 		}
 	}
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -735,14 +735,6 @@ void UVitruvioComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 
 void UVitruvioComponent::Generate(UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	// If the initial shape and RPK are valid but we have not yet loaded the attributes we load the attributes
-	// and regenerate afterwards
-	if (HasValidInputData() && !bAttributesReady)
-	{
-		EvaluateRuleAttributes(true, CallbackProxy);
-		return;
-	}
-
 	// If either the RPK, initial shape or attributes are not ready we can not generate
 	if (!HasValidInputData())
 	{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -560,6 +560,7 @@ void UVitruvioComponent::ProcessGenerateQueue()
 		{
 			Result.CallbackProxy->OnGenerateCompleted.Broadcast();
 		}
+		OnGenerateCompleted.Broadcast();
 	}
 }
 
@@ -579,6 +580,7 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 		{
 			AttributesEvaluation.CallbackProxy->OnAttributesEvaluated.Broadcast();
 		}
+		OnAttributesEvaluated.Broadcast();
 
 		if (GenerateAutomatically || AttributesEvaluation.bForceRegenerate)
 		{

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -297,6 +297,46 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 	}
 }
 
+void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh)
+{
+	if (InitialShape)
+	{
+		InitialShape->Uninitialize();
+		InitialShape->Rename(nullptr, GetTransientPackage()); // Remove from Owner
+	}
+
+	UStaticMeshInitialShape* NewInitialShape =
+		NewObject<UStaticMeshInitialShape>(GetOwner(), UStaticMeshInitialShape::StaticClass(), NAME_None, RF_Transient | RF_TextExportTransient);
+	NewInitialShape->Initialize(this, StaticMesh);
+
+	InitialShape = NewInitialShape;
+
+	if (GenerateAutomatically)
+	{
+		EvaluateRuleAttributes(true);
+	}
+}
+
+void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints)
+{
+	if (InitialShape)
+	{
+		InitialShape->Uninitialize();
+		InitialShape->Rename(nullptr, GetTransientPackage()); // Remove from Owner
+	}
+
+	USplineInitialShape* NewInitialShape =
+		NewObject<USplineInitialShape>(GetOwner(), USplineInitialShape::StaticClass(), NAME_None, RF_Transient | RF_TextExportTransient);
+	NewInitialShape->Initialize(this, SplinePoints);
+
+	InitialShape = NewInitialShape;
+
+	if (GenerateAutomatically)
+	{
+		EvaluateRuleAttributes(true);
+	}
+}
+
 const TMap<FString, URuleAttribute*>& UVitruvioComponent::GetAttributes() const
 {
 	return Attributes;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -746,9 +746,8 @@ void UVitruvioComponent::Generate(UGenerateCompletedCallbackProxy* CallbackProxy
 	// completed.
 	if (GenerateToken)
 	{
-		GenerateToken->RequestRegenerate();
-
-		return;
+		GenerateToken->Invalidate();
+		GenerateToken.Reset();
 	}
 
 	if (InitialShape)
@@ -768,14 +767,7 @@ void UVitruvioComponent::Generate(UGenerateCompletedCallbackProxy* CallbackProxy
 			}
 
 			GenerateToken.Reset();
-			if (Result.Token->IsRegenerateRequested())
-			{
-				Generate(CallbackProxy);
-			}
-			else
-			{
-				GenerateQueue.Enqueue({Result.Value, CallbackProxy});
-			}
+			GenerateQueue.Enqueue({Result.Value, CallbackProxy});
 		});
 		// clang-format on
 	}
@@ -917,8 +909,8 @@ void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate, UGenerateC
 	// has completed.
 	if (EvalAttributesInvalidationToken)
 	{
-		EvalAttributesInvalidationToken->RequestReEvaluateAttributes();
-		return;
+		EvalAttributesInvalidationToken->Invalidate();
+		EvalAttributesInvalidationToken.Reset();
 	}
 
 	bAttributesReady = false;
@@ -937,14 +929,7 @@ void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate, UGenerateC
 		}
 
 		EvalAttributesInvalidationToken.Reset();
-		if (Result.Token->IsReEvaluateRequested())
-		{
-			EvaluateRuleAttributes(ForceRegenerate, CallbackProxy);
-		}
-		else
-		{
-			AttributesEvaluationQueue.Enqueue({Result.Value, ForceRegenerate, CallbackProxy});
-		}
+		AttributesEvaluationQueue.Enqueue({Result.Value, ForceRegenerate, CallbackProxy});
 	});
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -327,6 +327,7 @@ void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh, UGenerateC
 
 	InitialShape = NewInitialShape;
 
+	RemoveGeneratedMeshes();
 	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 
@@ -344,6 +345,7 @@ void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& Splin
 
 	InitialShape = NewInitialShape;
 
+	RemoveGeneratedMeshes();
 	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -60,6 +60,7 @@ bool GetAttribute(const TMap<FString, URuleAttribute*>& Attributes, const FStrin
 	URuleAttribute const* const* FoundAttribute = Attributes.Find(Name);
 	if (!FoundAttribute)
 	{
+		OutValue = {};
 		return false;
 	}
 
@@ -67,10 +68,18 @@ bool GetAttribute(const TMap<FString, URuleAttribute*>& Attributes, const FStrin
 	A const* TAttribute = Cast<A>(Attribute);
 	if (!TAttribute)
 	{
+		OutValue = {};
 		return false;
 	}
 
-	OutValue = TAttribute->Value;
+	if constexpr (TIsTArray<T>::Value)
+	{
+		OutValue = TAttribute->Values;
+	}
+	else
+	{
+		OutValue = TAttribute->Value;
+	}
 
 	return true;
 }
@@ -99,14 +108,21 @@ void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttr
 		RuleAttribute->Name = Name;
 		RuleAttribute->DisplayName = WCHAR_TO_TCHAR(prtu::removeImport(prtu::removeStyle(*Name)).c_str());
 		RuleAttribute->ImportPath = WCHAR_TO_TCHAR(prtu::getFullImportPath(*Name).c_str());
-		RuleAttribute->Value = Value;
 
 		Attributes.Add(Name, RuleAttribute);
 
 		TAttribute = RuleAttribute;
 	}
 
-	TAttribute->Value = Value;
+	if constexpr (TIsTArray<T>::Value)
+	{
+		TAttribute->Values = Value;
+	}
+	else
+	{
+		TAttribute->Value = Value;
+	}
+
 	TAttribute->bUserSet = true;
 	VitruvioComponent->EvaluateRuleAttributes(VitruvioComponent->GenerateAutomatically, CallbackProxy);
 }
@@ -261,6 +277,17 @@ bool UVitruvioComponent::GetStringAttribute(const FString& Name, FString& OutVal
 	return GetAttribute<UStringAttribute, FString>(this->Attributes, Name, OutValue);
 }
 
+void UVitruvioComponent::SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bAddIfNonExisting,
+												 UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	SetAttribute<UStringArrayAttribute, TArray<FString>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+}
+
+bool UVitruvioComponent::GetStringArrayAttribute(const FString& Name, TArray<FString>& OutValue) const
+{
+	return GetAttribute<UStringArrayAttribute, TArray<FString>>(this->Attributes, Name, OutValue);
+}
+
 void UVitruvioComponent::SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	SetAttribute<UBoolAttribute, bool>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
@@ -271,6 +298,17 @@ bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) c
 	return GetAttribute<UBoolAttribute, bool>(this->Attributes, Name, OutValue);
 }
 
+void UVitruvioComponent::SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bAddIfNonExisting,
+											   UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	SetAttribute<UBoolArrayAttribute, TArray<bool>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+}
+
+bool UVitruvioComponent::GetBoolArrayAttribute(const FString& Name, TArray<bool>& OutValue) const
+{
+	return GetAttribute<UBoolArrayAttribute, TArray<bool>>(this->Attributes, Name, OutValue);
+}
+
 void UVitruvioComponent::SetFloatAttribute(const FString& Name, double Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	SetAttribute<UFloatAttribute, double>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
@@ -279,6 +317,17 @@ void UVitruvioComponent::SetFloatAttribute(const FString& Name, double Value, bo
 bool UVitruvioComponent::GetFloatAttribute(const FString& Name, double& OutValue) const
 {
 	return GetAttribute<UFloatAttribute, double>(this->Attributes, Name, OutValue);
+}
+
+void UVitruvioComponent::SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bAddIfNonExisting,
+												UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	SetAttribute<UFloatArrayAttribute, TArray<double>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+}
+
+bool UVitruvioComponent::GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const
+{
+	return GetAttribute<UFloatArrayAttribute, TArray<double>>(this->Attributes, Name, OutValue);
 }
 
 void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting,

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -343,22 +343,22 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 
 		if (FCString::IsNumeric(*Value))
 		{
-			SetFloatAttribute(Key, FCString::Atof(*Value), bAddIfNonExisting, CallbackProxy);
+			SetFloatAttribute(Key, FCString::Atof(*Value), bAddIfNonExisting, nullptr);
 		}
 		else if (Value == "true" || Value == "false")
 		{
-			SetBoolAttribute(Key, Value == "true", bAddIfNonExisting, CallbackProxy);
+			SetBoolAttribute(Key, Value == "true", bAddIfNonExisting, nullptr);
 		}
 		else
 		{
-			SetStringAttribute(Key, Value, bAddIfNonExisting, CallbackProxy);
+			SetStringAttribute(Key, Value, bAddIfNonExisting, nullptr);
 		}
 	}
 
 	GenerateAutomatically = bOldGenerateAutomatically;
 	if (HasValidInputData())
 	{
-		EvaluateRuleAttributes(GenerateAutomatically);
+		EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -103,13 +103,13 @@ bool GetAttribute(const TMap<FString, URuleAttribute*>& Attributes, const FStrin
 
 template <typename A, typename T>
 void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttribute*>& Attributes, const FString& Name, const T& Value,
-				  bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
+				  UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	// Initialize component if necessary
 	VitruvioComponent->Initialize();
 	
 	URuleAttribute** FoundAttribute = Attributes.Find(Name);
-	if (!FoundAttribute && !bAddIfNonExisting)
+	if (!FoundAttribute)
 	{
 		return;
 	}
@@ -118,20 +118,7 @@ void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttr
 	A* TAttribute = Cast<A>(Attribute);
 	if (!TAttribute)
 	{
-		if (!bAddIfNonExisting)
-		{
-			return;
-		}
-
-		// Create new attribute if it does not exist and bAddIfNonExisting is true
-		A* RuleAttribute = NewObject<A>(VitruvioComponent->GetOuter());
-		RuleAttribute->Name = Name;
-		RuleAttribute->DisplayName = WCHAR_TO_TCHAR(prtu::removeImport(prtu::removeStyle(*Name)).c_str());
-		RuleAttribute->ImportPath = WCHAR_TO_TCHAR(prtu::getFullImportPath(*Name).c_str());
-
-		Attributes.Add(Name, RuleAttribute);
-
-		TAttribute = RuleAttribute;
+		return;
 	}
 
 	if constexpr (TIsTArray<T>::Value)
@@ -286,10 +273,9 @@ void UVitruvioComponent::SetRpk(URulePackage* RulePackage, UGenerateCompletedCal
 	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
 }
 
-void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting,
-											UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UStringAttribute, FString>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UStringAttribute, FString>(this, this->Attributes, Name, Value, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetStringAttribute(const FString& Name, FString& OutValue) const
@@ -297,10 +283,9 @@ bool UVitruvioComponent::GetStringAttribute(const FString& Name, FString& OutVal
 	return GetAttribute<UStringAttribute, FString>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bAddIfNonExisting,
-												 UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UStringArrayAttribute, TArray<FString>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UStringArrayAttribute, TArray<FString>>(this, this->Attributes, Name, Values, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetStringArrayAttribute(const FString& Name, TArray<FString>& OutValue) const
@@ -308,9 +293,9 @@ bool UVitruvioComponent::GetStringArrayAttribute(const FString& Name, TArray<FSt
 	return GetAttribute<UStringArrayAttribute, TArray<FString>>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetBoolAttribute(const FString& Name, bool Value, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UBoolAttribute, bool>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UBoolAttribute, bool>(this, this->Attributes, Name, Value, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) const
@@ -318,10 +303,9 @@ bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) c
 	return GetAttribute<UBoolAttribute, bool>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bAddIfNonExisting,
-											   UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UBoolArrayAttribute, TArray<bool>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UBoolArrayAttribute, TArray<bool>>(this, this->Attributes, Name, Values, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetBoolArrayAttribute(const FString& Name, TArray<bool>& OutValue) const
@@ -329,9 +313,9 @@ bool UVitruvioComponent::GetBoolArrayAttribute(const FString& Name, TArray<bool>
 	return GetAttribute<UBoolArrayAttribute, TArray<bool>>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetFloatAttribute(const FString& Name, double Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetFloatAttribute(const FString& Name, double Value, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UFloatAttribute, double>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UFloatAttribute, double>(this, this->Attributes, Name, Value, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetFloatAttribute(const FString& Name, double& OutValue) const
@@ -339,10 +323,9 @@ bool UVitruvioComponent::GetFloatAttribute(const FString& Name, double& OutValue
 	return GetAttribute<UFloatAttribute, double>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bAddIfNonExisting,
-												UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UFloatArrayAttribute, TArray<double>>(this, this->Attributes, Name, Values, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UFloatArrayAttribute, TArray<double>>(this, this->Attributes, Name, Values, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const
@@ -350,8 +333,7 @@ bool UVitruvioComponent::GetFloatArrayAttribute(const FString& Name, TArray<doub
 	return GetAttribute<UFloatArrayAttribute, TArray<double>>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting,
-									   UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	// Initialize component if necessary
 	Initialize();
@@ -366,15 +348,15 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 
 		if (FCString::IsNumeric(*Value))
 		{
-			SetFloatAttribute(Key, FCString::Atof(*Value), bAddIfNonExisting, nullptr);
+			SetFloatAttribute(Key, FCString::Atof(*Value), nullptr);
 		}
 		else if (Value == "true" || Value == "false")
 		{
-			SetBoolAttribute(Key, Value == "true", bAddIfNonExisting, nullptr);
+			SetBoolAttribute(Key, Value == "true", nullptr);
 		}
 		else
 		{
-			SetStringAttribute(Key, Value, bAddIfNonExisting, nullptr);
+			SetStringAttribute(Key, Value, nullptr);
 		}
 	}
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -77,7 +77,7 @@ bool GetAttribute(const TMap<FString, URuleAttribute*>& Attributes, const FStrin
 
 template <typename A, typename T>
 void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttribute*>& Attributes, const FString& Name, const T& Value,
-				  bool bAddIfNonExisting)
+				  bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	URuleAttribute** FoundAttribute = Attributes.Find(Name);
 	if (!FoundAttribute && !bAddIfNonExisting)
@@ -236,7 +236,7 @@ bool UVitruvioComponent::IsReadyToGenerate() const
 	return HasValidInputData() && bAttributesReady;
 }
 
-void UVitruvioComponent::SetRpk(URulePackage* RulePackage)
+void UVitruvioComponent::SetRpk(URulePackage* RulePackage, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	if (this->Rpk == RulePackage)
 	{
@@ -255,9 +255,10 @@ void UVitruvioComponent::SetRpk(URulePackage* RulePackage)
 	}
 }
 
-void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting)
+void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting,
+											UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UStringAttribute, FString>(this, this->Attributes, Name, Value, bAddIfNonExisting);
+	SetAttribute<UStringAttribute, FString>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetStringAttribute(const FString& Name, FString& OutValue) const
@@ -265,9 +266,9 @@ bool UVitruvioComponent::GetStringAttribute(const FString& Name, FString& OutVal
 	return GetAttribute<UStringAttribute, FString>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting)
+void UVitruvioComponent::SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UBoolAttribute, bool>(this, this->Attributes, Name, Value, bAddIfNonExisting);
+	SetAttribute<UBoolAttribute, bool>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) const
@@ -275,9 +276,9 @@ bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) c
 	return GetAttribute<UBoolAttribute, bool>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetFloatAttribute(const FString& Name, float Value, bool bAddIfNonExisting)
+void UVitruvioComponent::SetFloatAttribute(const FString& Name, float Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UFloatAttribute, float>(this, this->Attributes, Name, Value, bAddIfNonExisting);
+	SetAttribute<UFloatAttribute, float>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
 }
 
 bool UVitruvioComponent::GetFloatAttribute(const FString& Name, float& OutValue) const
@@ -285,7 +286,8 @@ bool UVitruvioComponent::GetFloatAttribute(const FString& Name, float& OutValue)
 	return GetAttribute<UFloatAttribute, float>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting)
+void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting,
+									   UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	const bool bOldGenerateAutomatically = GenerateAutomatically;
 	GenerateAutomatically = false;
@@ -316,7 +318,7 @@ void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttribut
 	}
 }
 
-void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh)
+void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	if (InitialShape)
 	{
@@ -336,7 +338,7 @@ void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh)
 	}
 }
 
-void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints)
+void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	if (InitialShape)
 	{
@@ -468,11 +470,11 @@ void UVitruvioComponent::ProcessGenerateQueue()
 	if (!GenerateQueue.IsEmpty())
 	{
 		// Get from queue and build meshes
-		FGenerateResultDescription Result;
+		FGenerateQueueItem Result;
 		GenerateQueue.Dequeue(Result);
 
 		FConvertedGenerateResult ConvertedResult =
-			BuildResult(Result, VitruvioModule::Get().GetMaterialCache(), VitruvioModule::Get().GetTextureCache());
+			BuildResult(Result.GenerateResultDescription, VitruvioModule::Get().GetMaterialCache(), VitruvioModule::Get().GetTextureCache());
 
 		Reports = ConvertedResult.Reports;
 
@@ -562,6 +564,11 @@ void UVitruvioComponent::ProcessGenerateQueue()
 		HasGeneratedMesh = true;
 
 		InitialShape->SetHidden(HideAfterGeneration);
+
+		if (Result.CallbackProxy)
+		{
+			Result.CallbackProxy->OnGenerateCompleted.Broadcast();
+		}
 	}
 }
 
@@ -569,7 +576,7 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 {
 	if (!AttributesEvaluationQueue.IsEmpty())
 	{
-		FAttributesEvaluation AttributesEvaluation;
+		FAttributesEvaluationQueueItem AttributesEvaluation;
 		AttributesEvaluationQueue.Dequeue(AttributesEvaluation);
 
 		AttributesEvaluation.AttributeMap->UpdateUnrealAttributeMap(Attributes, this);
@@ -577,9 +584,14 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 		bAttributesReady = true;
 		bNotifyAttributeChange = true;
 
+		if (AttributesEvaluation.CallbackProxy)
+		{
+			AttributesEvaluation.CallbackProxy->OnAttributesEvaluated.Broadcast();
+		}
+
 		if (GenerateAutomatically || AttributesEvaluation.bForceRegenerate)
 		{
-			Generate();
+			Generate(AttributesEvaluation.CallbackProxy);
 		}
 	}
 }
@@ -679,13 +691,13 @@ void UVitruvioComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 #endif
 }
 
-void UVitruvioComponent::Generate()
+void UVitruvioComponent::Generate(UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	// If the initial shape and RPK are valid but we have not yet loaded the attributes we load the attributes
 	// and regenerate afterwards
 	if (HasValidInputData() && !bAttributesReady)
 	{
-		EvaluateRuleAttributes(true);
+		EvaluateRuleAttributes(true, CallbackProxy);
 		return;
 	}
 
@@ -713,7 +725,7 @@ void UVitruvioComponent::Generate()
 		GenerateToken = GenerateResult.Token;
 
 		// clang-format off
-		GenerateResult.Result.Next([this](const FGenerateResult::ResultType& Result)
+		GenerateResult.Result.Next([this, CallbackProxy](const FGenerateResult::ResultType& Result)
 		{
 			FScopeLock Lock(&Result.Token->Lock);
 
@@ -724,11 +736,11 @@ void UVitruvioComponent::Generate()
 			GenerateToken.Reset();
 			if (Result.Token->IsRegenerateRequested())
 			{
-				Generate();
+				Generate(CallbackProxy);
 			}
 			else
 			{
-				GenerateQueue.Enqueue(Result.Value);
+				GenerateQueue.Enqueue({Result.Value, CallbackProxy});
 			}
 		});
 		// clang-format on
@@ -861,7 +873,7 @@ void UVitruvioComponent::SetInitialShapeType(const TSubclassOf<UInitialShape>& T
 
 #endif // WITH_EDITOR
 
-void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate)
+void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	if (!HasValidInputData())
 	{
@@ -883,7 +895,7 @@ void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate)
 
 	EvalAttributesInvalidationToken = AttributesResult.Token;
 
-	AttributesResult.Result.Next([this, ForceRegenerate](const FAttributeMapResult::ResultType& Result) {
+	AttributesResult.Result.Next([this, CallbackProxy, ForceRegenerate](const FAttributeMapResult::ResultType& Result) {
 		FScopeLock(&Result.Token->Lock);
 
 		if (Result.Token->IsInvalid())
@@ -894,11 +906,11 @@ void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate)
 		EvalAttributesInvalidationToken.Reset();
 		if (Result.Token->IsReEvaluateRequested())
 		{
-			EvaluateRuleAttributes(ForceRegenerate);
+			EvaluateRuleAttributes(ForceRegenerate, CallbackProxy);
 		}
 		else
 		{
-			AttributesEvaluationQueue.Enqueue({Result.Value, ForceRegenerate});
+			AttributesEvaluationQueue.Enqueue({Result.Value, ForceRegenerate, CallbackProxy});
 		}
 	});
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -266,6 +266,37 @@ bool UVitruvioComponent::GetFloatAttribute(const FString& Name, float& OutValue)
 	return GetAttribute<UFloatAttribute, float>(this->Attributes, Name, OutValue);
 }
 
+void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes)
+{
+	const bool bOldGenerateAutomatically = GenerateAutomatically;
+	GenerateAutomatically = false;
+
+	for (const auto& KeyValues : NewAttributes)
+	{
+		const FString& Value = KeyValues.Value;
+		const FString& Key = KeyValues.Key;
+
+		if (FCString::IsNumeric(*Value))
+		{
+			SetFloatAttribute(Key, FCString::Atof(*Value));
+		}
+		else if (Value == "true" || Value == "false")
+		{
+			SetBoolAttribute(Key, Value == "true");
+		}
+		else
+		{
+			SetStringAttribute(Key, Value);
+		}
+	}
+
+	GenerateAutomatically = bOldGenerateAutomatically;
+	if (GenerateAutomatically && IsReadyToGenerate())
+	{
+		EvaluateRuleAttributes(true);
+	}
+}
+
 const TMap<FString, URuleAttribute*>& UVitruvioComponent::GetAttributes() const
 {
 	return Attributes;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -609,6 +609,7 @@ void UVitruvioComponent::ProcessGenerateQueue()
 		{
 			Result.CallbackProxy->OnGenerateCompleted.Broadcast();
 			Result.CallbackProxy->OnGenerateCompletedCpp.Broadcast();
+			Result.CallbackProxy->SetReadyToDestroy();
 		}
 		OnGenerateCompleted.Broadcast();
 	}
@@ -637,6 +638,10 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 		{
 			Generate(AttributesEvaluation.CallbackProxy);
 		}
+		else if (AttributesEvaluation.CallbackProxy)
+		{
+			AttributesEvaluation.CallbackProxy->SetReadyToDestroy();
+		} 
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -271,14 +271,14 @@ bool UVitruvioComponent::GetBoolAttribute(const FString& Name, bool& OutValue) c
 	return GetAttribute<UBoolAttribute, bool>(this->Attributes, Name, OutValue);
 }
 
-void UVitruvioComponent::SetFloatAttribute(const FString& Name, float Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
+void UVitruvioComponent::SetFloatAttribute(const FString& Name, double Value, bool bAddIfNonExisting, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	SetAttribute<UFloatAttribute, float>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
+	SetAttribute<UFloatAttribute, double>(this, this->Attributes, Name, Value, bAddIfNonExisting, CallbackProxy);
 }
 
-bool UVitruvioComponent::GetFloatAttribute(const FString& Name, float& OutValue) const
+bool UVitruvioComponent::GetFloatAttribute(const FString& Name, double& OutValue) const
 {
-	return GetAttribute<UFloatAttribute, float>(this->Attributes, Name, OutValue);
+	return GetAttribute<UFloatAttribute, double>(this->Attributes, Name, OutValue);
 }
 
 void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting,

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -608,6 +608,7 @@ void UVitruvioComponent::ProcessGenerateQueue()
 		if (Result.CallbackProxy)
 		{
 			Result.CallbackProxy->OnGenerateCompleted.Broadcast();
+			Result.CallbackProxy->OnGenerateCompletedCpp.Broadcast();
 		}
 		OnGenerateCompleted.Broadcast();
 	}
@@ -628,10 +629,11 @@ void UVitruvioComponent::ProcessAttributesEvaluationQueue()
 		if (AttributesEvaluation.CallbackProxy)
 		{
 			AttributesEvaluation.CallbackProxy->OnAttributesEvaluated.Broadcast();
+			AttributesEvaluation.CallbackProxy->OnAttributesEvaluatedCpp.Broadcast();
 		}
 		OnAttributesEvaluated.Broadcast();
 
-		if (GenerateAutomatically || AttributesEvaluation.bForceRegenerate)
+		if (AttributesEvaluation.bForceRegenerate)
 		{
 			Generate(AttributesEvaluation.CallbackProxy);
 		}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -372,7 +372,7 @@ void UVitruvioComponent::SetRpk(URulePackage* RulePackage, bool bGenerateModel, 
 	bNotifyAttributeChange = true;
 
 	RemoveGeneratedMeshes();
-	EvaluateRuleAttributes(GenerateAutomatically, CallbackProxy);
+	EvaluateRuleAttributes(bGenerateModel, CallbackProxy);
 }
 
 void UVitruvioComponent::SetStringAttribute(const FString& Name, const FString& Value, bool bGenerateModel,

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -105,7 +105,6 @@ template <typename A, typename T>
 void SetAttribute(UVitruvioComponent* VitruvioComponent, TMap<FString, URuleAttribute*>& Attributes, const FString& Name, const T& Value,
 				  bool bEvaluateAttributes, bool bGenerateModel, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	// Initialize component if necessary
 	VitruvioComponent->Initialize();
 
 	URuleAttribute** FoundAttribute = Attributes.Find(Name);
@@ -345,7 +344,6 @@ bool UVitruvioComponent::GetFloatArrayAttribute(const FString& Name, TArray<doub
 void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bGenerateModel,
 									   UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	// Initialize component if necessary
 	Initialize();
 
 	for (const auto& KeyValues : NewAttributes)
@@ -474,9 +472,6 @@ void UVitruvioComponent::Initialize()
 	OnHierarchyChanged.Broadcast(this);
 
 	CalculateRandomSeed();
-
-	// Evaluate rule attributes and possibly generate the model
-	EvaluateRuleAttributes(GenerateAutomatically);
 }
 
 void UVitruvioComponent::PostLoad()
@@ -487,6 +482,7 @@ void UVitruvioComponent::PostLoad()
 	if (CreationMethod == EComponentCreationMethod::Instance)
 	{
 		Initialize();
+		EvaluateRuleAttributes(GenerateAutomatically);
 	}
 }
 
@@ -498,6 +494,7 @@ void UVitruvioComponent::OnComponentCreated()
 	if (CreationMethod == EComponentCreationMethod::Instance)
 	{
 		Initialize();
+		EvaluateRuleAttributes(GenerateAutomatically);
 	}
 }
 
@@ -739,7 +736,6 @@ void UVitruvioComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 
 void UVitruvioComponent::Generate(UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	// Initialize component if necessary
 	Initialize();
 
 	// If either the RPK, initial shape or attributes are not ready we can not generate
@@ -907,7 +903,6 @@ void UVitruvioComponent::SetInitialShapeType(const TSubclassOf<UInitialShape>& T
 
 void UVitruvioComponent::EvaluateRuleAttributes(bool ForceRegenerate, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	// Initialize component if necessary
 	Initialize();
 
 	// If we don't have valid input data (initial shape and rpk) we can not evaluate the rule attribtues

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -65,12 +65,10 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value,
-															  bool bAddIfNonExisting = false);
+	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value);
 
 	/**
 	 * Sets the string attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
@@ -78,12 +76,10 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value,
-															   bool bAddIfNonExisting = false);
+	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value);
 
 	/**
 	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
@@ -91,12 +87,10 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value,
-															 bool bAddIfNonExisting = false);
+	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value);
 
 	/**
 	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
@@ -104,12 +98,11 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																   const TArray<double>& Values, bool bAddIfNonExisting = false);
+																   const TArray<double>& Values);
 
 	/**
 	 * Sets a string array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
@@ -117,12 +110,11 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																	const TArray<FString>& Values, bool bAddIfNonExisting = false);
+																	const TArray<FString>& Values);
 
 	/**
 	 * Sets a bool array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
@@ -130,12 +122,11 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																  const TArray<bool>& Values, bool bAddIfNonExisting = false);
+																  const TArray<bool>& Values);
 
 	/**
 	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
@@ -145,12 +136,10 @@ public:
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param NewAttributes The attributes to be set.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes,
-														  bool bAddIfNonExisting = false);
+	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if GenerateAutomatically is set to true.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -43,144 +43,140 @@ public:
 	FGenerateCompletedDelegate OnGenerateCompleted;
 
 	/**
-	 * Sets the given Rpk and possibly invalidates already loaded attributes. This will trigger a reevaluation of the attributes and if
-	 * GenerateAutomatically is set to true also regenerates the the model.
+	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage);
 
 	/**
-	 * Generates a model using the current RPK and initial shapes. If attributes are not loaded yet they will first be evaluated. If no Initial Shape
-	 * or RPK is set this method will do nothing.
+	 * Generates a model using the current Rule Package and initial shape. If the attributes are not yet available, they will first be evaluated. If
+	 * no Initial Shape or Rule Package is set, this method will do nothing.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* Generate(UVitruvioComponent* VitruvioComponent);
 
 	/**
-	 * Sets float attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the float attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value,
 															  bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets string attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the string attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value,
 															   bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets bool attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value,
 															 bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets the float array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
 																   const TArray<double>& Values, bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets the string array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets a string array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
 																	const TArray<FString>& Values, bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets the bool array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets a bool array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
-	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
 																  const TArray<bool>& Values, bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
-	 * The type of the attribute will be deduced from its string representation: <br>
-	 * "1.0" for the float 1.0 <br>
-	 * "hello" for the string "hello" and <br>
-	 * "true" for the bool true <br>
+	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
+	 * attributes, the key-value pair will be ignored. If bAddIfNonExisting is set to true, new attributes will be added in case they are not found in
+	 * the current attributes. Regenerates the model if GenerateAutomatically is set to true. The type of the attribute will be deduced from its
+	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
 	 *
-	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
-	 * @param NewAttributes the attributes to be set
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
+	 * @param NewAttributes The attributes to be set.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes,
 														  bool bAddIfNonExisting = false);
 
 	/**
-	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.
+	 * Sets the given static mesh as initial shape. Regenerates the model if GenerateAutomatically is set to true.
 	 *
-	 * @param StaticMesh the new initial shape static mesh.
+	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
+	 * @param StaticMesh The new initial shape static mesh.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh);
 
 	/**
-	 * Sets the given spline points as initial shape. Regenerates the model if generate automatically is set to true.
+	 * Sets the given spline points as initial shape. Regenerates the model if GenerateAutomatically is set to true.
 	 *
-	 * @param SplinePoints the new initial shape spline points.
+	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
+	 * @param SplinePoints The new initial shape spline points.
+	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetSplineInitialShape(UVitruvioComponent* VitruvioComponent, const TArray<FSplinePoint>& SplinePoints);
 
 	/**
-	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (according to
+	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (see
 	 * CanConvertToVitruvioActor) it will be ignored.
 	 *
-	 * @param Actors the Actors to convert to VitruvioActors
-	 * @param OutVitruvioActors the converted VitruvioActors
-	 * @param Rpk the optional RulePackage
+	 * @param Actors The Actors to convert to VitruvioActors.
+	 * @param OutVitruvioActors The converted VitruvioActors.
+	 * @param Rpk The optional RulePackage.
 	 * @param bGenerateModels Whether a model should be generated after the conversion. Only applicable if the RulePackage has been set.
-	 * @return the converted VitruvioActors
+	 * @return The converted VitruvioActors.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* ConvertToVitruvioActor(const TArray<AActor*>& Actors, TArray<AVitruvioActor*>& OutVitruvioActors,

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -66,7 +66,7 @@ public:
 	static UGenerateCompletedCallbackProxy* Generate(UVitruvioComponent* VitruvioComponent);
 
 	/**
-	 * Sets the float attribute with the given Name to the given value.
+	 * Sets the float attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
@@ -79,7 +79,7 @@ public:
 															  bool bGenerateModel = true);
 
 	/**
-	 * Sets the string attribute with the given Name to the given value.
+	 * Sets the string attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute to set.
@@ -92,7 +92,7 @@ public:
 															   bool bGenerateModel = true);
 
 	/**
-	 * Sets the bool attribute with the given Name to the given value.
+	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
@@ -105,7 +105,7 @@ public:
 															 bool bGenerateModel = true);
 
 	/**
-	 * Sets the float array attribute with the given Name to the given value.
+	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
@@ -118,7 +118,7 @@ public:
 																   const TArray<double>& Values, bool bGenerateModel = true);
 
 	/**
-	 * Sets a string array attribute with the given Name to the given value.
+	 * Sets a string array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
@@ -131,7 +131,7 @@ public:
 																	const TArray<FString>& Values, bool bGenerateModel = true);
 
 	/**
-	 * Sets a bool array attribute with the given Name to the given value.
+	 * Sets a bool array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param Name The name of the attribute.
@@ -144,10 +144,10 @@ public:
 																  const TArray<bool>& Values, bool bGenerateModel = true);
 
 	/**
-	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
-	 * attributes, the key-value pair will be ignored. If bAddIfNonExisting is set to true, new attributes will be added in case they are not found in
-	 * the current attributes. Regenerates the model if GenerateAutomatically is set to true. The type of the attribute will be deduced from its
+	 * Sets the given attributes. If a key from the NewAttributes is not found in the current attributes, the key-value pair will be ignored.
+	 * Regenerates the model if bGenerateModel is set to true. The type of the attribute will be deduced from its
 	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
+	 * array values are separated via a comma eg: "1.3,4.5,0" for a float array with the values 1.3, 4.5 and 0.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param NewAttributes The attributes to be set.
@@ -159,7 +159,7 @@ public:
 														  bool bGenerateModel = true);
 
 	/**
-	 * Sets the given static mesh as initial shape. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param StaticMesh The new initial shape static mesh.
@@ -171,7 +171,7 @@ public:
 																bool bGenerateModel = true);
 
 	/**
-	 * Sets the given spline points as initial shape. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the given spline points as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param SplinePoints The new initial shape spline points.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -32,15 +32,19 @@ class VITRUVIO_API UGenerateCompletedCallbackProxy final : public UBlueprintAsyn
 
 public:
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerateCompletedDelegate);
+	DECLARE_MULTICAST_DELEGATE(FGenerateCompletedDelegateCpp);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegate);
+	DECLARE_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegateCpp);
 
 	/** Called after the attributes have been evaluated. Note that it is not guaranteed that this callback is ever called. */
 	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Attributes Evaluated"), Category = "Vitruvio")
 	FOnAttributesEvaluatedDelegate OnAttributesEvaluated;
+	FOnAttributesEvaluatedDelegateCpp OnAttributesEvaluatedCpp;
 
 	/** Called after generate has completed. Note that it is not guaranteed that this callback is ever called. */
 	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Generate Completed"), Category = "Vitruvio")
 	FGenerateCompletedDelegate OnGenerateCompleted;
+	FGenerateCompletedDelegateCpp OnGenerateCompletedCpp;
 
 	/**
 	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
@@ -172,13 +176,15 @@ public:
 	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (see
 	 * CanConvertToVitruvioActor) it will be ignored.
 	 *
+	 * @param WorldContextObject
 	 * @param Actors The Actors to convert to VitruvioActors.
 	 * @param OutVitruvioActors The converted VitruvioActors.
 	 * @param Rpk The optional RulePackage.
 	 * @param bGenerateModels Whether a model should be generated after the conversion. Only applicable if the RulePackage has been set.
 	 * @return The converted VitruvioActors.
 	 */
-	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* ConvertToVitruvioActor(const TArray<AActor*>& Actors, TArray<AVitruvioActor*>& OutVitruvioActors,
-																   URulePackage* Rpk = nullptr, bool bGenerateModels = true);
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true, WorldContext = "WorldContextObject"), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* ConvertToVitruvioActor(UObject* WorldContextObject, const TArray<AActor*>& Actors,
+																   TArray<AVitruvioActor*>& OutVitruvioActors, URulePackage* Rpk = nullptr,
+																   bool bGenerateModels = true);
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -1,0 +1,146 @@
+/* Copyright 2021 Esri
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Components/SplineComponent.h"
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+
+#include "GenerateCompletedCallbackProxy.generated.h"
+
+class AVitruvioActor;
+class URulePackage;
+class UVitruvioComponent;
+
+UCLASS()
+class VITRUVIO_API UGenerateCompletedCallbackProxy final : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+public:
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerateCompletedDelegate);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegate);
+
+	/** Called after the attributes have been evaluated. Note that it is not guaranteed that this callback is ever called. */
+	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Attributes Evaluated"), Category = "Vitruvio")
+	FOnAttributesEvaluatedDelegate OnAttributesEvaluated;
+
+	/** Called after generate has completed. Note that it is not guaranteed that this callback is ever called. */
+	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Generate Completed"), Category = "Vitruvio")
+	FGenerateCompletedDelegate OnGenerateCompleted;
+
+	/**
+	 * Sets the given Rpk and possibly invalidates already loaded attributes. This will trigger a reevaluation of the attributes and if
+	 * GenerateAutomatically is set to true also regenerates the the model.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage);
+
+	/**
+	 * Generates a model using the current RPK and initial shapes. If attributes are not loaded yet they will first be evaluated. If no Initial Shape
+	 * or RPK is set this method will do nothing.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* Generate(UVitruvioComponent* VitruvioComponent);
+
+	/**
+	 * Sets float attributes used for generation.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute.
+	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value,
+															  bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets string attributes used for generation.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute to set.
+	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value,
+															   bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets bool attributes used for generation.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute.
+	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value,
+															 bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * The type of the attribute will be deduced from its string representation: <br>
+	 * "1.0" for the float 1.0 <br>
+	 * "hello" for the string "hello" and <br>
+	 * "true" for the bool true <br>
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param NewAttributes the attributes to be set
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes,
+														  bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.
+	 *
+	 * @param StaticMesh the new initial shape static mesh.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh);
+
+	/**
+	 * Sets the given spline points as initial shape. Regenerates the model if generate automatically is set to true.
+	 *
+	 * @param SplinePoints the new initial shape spline points.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetSplineInitialShape(UVitruvioComponent* VitruvioComponent, const TArray<FSplinePoint>& SplinePoints);
+
+	/**
+	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (according to
+	 * CanConvertToVitruvioActor) it will be ignored.
+	 *
+	 * @param Actors the Actors to convert to VitruvioActors
+	 * @param OutVitruvioActors the converted VitruvioActors
+	 * @param Rpk the optional RulePackage
+	 * @param bGenerateModels Whether a model should be generated after the conversion. Only applicable if the RulePackage has been set.
+	 * @return the converted VitruvioActors
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* ConvertToVitruvioActor(const TArray<AActor*>& Actors, TArray<AVitruvioActor*>& OutVitruvioActors,
+																   URulePackage* Rpk = nullptr, bool bGenerateModels = true);
+};

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -31,20 +31,20 @@ class VITRUVIO_API UGenerateCompletedCallbackProxy final : public UBlueprintAsyn
 	GENERATED_BODY()
 
 public:
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerateCompletedDelegate);
-	DECLARE_MULTICAST_DELEGATE(FGenerateCompletedDelegateCpp);
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegate);
-	DECLARE_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegateCpp);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerateCompletedDynDelegate);
+	DECLARE_MULTICAST_DELEGATE(FGenerateCompletedDelegate);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttributesEvaluatedDynDelegate);
+	DECLARE_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegate);
 
 	/** Called after the attributes have been evaluated. Note that it is not guaranteed that this callback is ever called. */
 	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Attributes Evaluated"), Category = "Vitruvio")
+	FOnAttributesEvaluatedDynDelegate OnAttributesEvaluatedBlueprint;
 	FOnAttributesEvaluatedDelegate OnAttributesEvaluated;
-	FOnAttributesEvaluatedDelegateCpp OnAttributesEvaluatedCpp;
 
 	/** Called after generate has completed. Note that it is not guaranteed that this callback is ever called. */
 	UPROPERTY(BlueprintAssignable, meta = (DisplayName = "Generate Completed"), Category = "Vitruvio")
+	FGenerateCompletedDynDelegate OnGenerateCompletedBlueprint;
 	FGenerateCompletedDelegate OnGenerateCompleted;
-	FGenerateCompletedDelegateCpp OnGenerateCompletedCpp;
 
 	/**
 	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -99,6 +99,48 @@ public:
 															 bool bAddIfNonExisting = false);
 
 	/**
+	 * Sets the float array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																   const TArray<double>& Values, bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets the string array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																	const TArray<FString>& Values, bool bAddIfNonExisting = false);
+
+	/**
+	 * Sets the bool array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
+																  const TArray<bool>& Values, bool bAddIfNonExisting = false);
+
+	/**
 	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.
 	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
 	 * The type of the attribute will be deduced from its string representation: <br>

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -47,10 +47,16 @@ public:
 	FGenerateCompletedDelegate OnGenerateCompleted;
 
 	/**
-	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
+	 * Sets the given Rule Package. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage);
+	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage, bool bGenerateModel = true);
+
+	/**
+	 * Sets the random seed used for generation. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetRandomSeed(UVitruvioComponent* VitruvioComponent, int32 NewRandomSeed, bool bGenerateModel = true);
 
 	/**
 	 * Generates a model using the current Rule Package and initial shape. If the attributes are not yet available, they will first be evaluated. If
@@ -60,73 +66,82 @@ public:
 	static UGenerateCompletedCallbackProxy* Generate(UVitruvioComponent* VitruvioComponent);
 
 	/**
-	 * Sets the float attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the float attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value);
+	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value,
+															  bool bGenerateModel = true);
 
 	/**
-	 * Sets the string attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the string attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value);
+	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value,
+															   bool bGenerateModel = true);
 
 	/**
-	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the bool attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value);
+	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value,
+															 bool bGenerateModel = true);
 
 	/**
-	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the float array attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																   const TArray<double>& Values);
+																   const TArray<double>& Values, bool bGenerateModel = true);
 
 	/**
-	 * Sets a string array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets a string array attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																	const TArray<FString>& Values);
+																	const TArray<FString>& Values, bool bGenerateModel = true);
 
 	/**
-	 * Sets a bool array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets a bool array attribute with the given Name to the given value.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																  const TArray<bool>& Values);
+																  const TArray<bool>& Values, bool bGenerateModel = true);
 
 	/**
 	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
@@ -136,30 +151,36 @@ public:
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param NewAttributes The attributes to be set.
+	 * @param bGenerateModel Whether a model should be generated after the attributes have been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes);
+	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes,
+														  bool bGenerateModel = true);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param StaticMesh The new initial shape static mesh.
+	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh);
+	static UGenerateCompletedCallbackProxy* SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh,
+																bool bGenerateModel = true);
 
 	/**
 	 * Sets the given spline points as initial shape. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param SplinePoints The new initial shape spline points.
+	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetSplineInitialShape(UVitruvioComponent* VitruvioComponent, const TArray<FSplinePoint>& SplinePoints);
+	static UGenerateCompletedCallbackProxy* SetSplineInitialShape(UVitruvioComponent* VitruvioComponent, const TArray<FSplinePoint>& SplinePoints,
+																  bool bGenerateModel = true);
 
 	/**
 	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (see

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -126,6 +126,12 @@ public:
 		return false;
 	}
 
+	virtual USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor) const
+	{
+		unimplemented();
+		return nullptr;
+	}
+
 	virtual void SetHidden(bool bHidden) {}
 
 	virtual bool CanDestroy();
@@ -156,6 +162,7 @@ public:
 	virtual void Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
 	void Initialize(UVitruvioComponent* Component, UStaticMesh* StaticMesh);
 	virtual bool CanConstructFrom(AActor* Owner) const override;
+	virtual USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor) const override;
 	virtual void SetHidden(bool bHidden) override;
 
 #if WITH_EDITOR
@@ -182,6 +189,7 @@ public:
 	virtual void Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
 	void Initialize(UVitruvioComponent* Component, const TArray<FSplinePoint>& SplinePoints);
 	virtual bool CanConstructFrom(AActor* Owner) const override;
+	virtual USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor) const override;
 
 #if WITH_EDITOR
 	virtual bool IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -154,6 +154,7 @@ public:
 
 	virtual void Initialize(UVitruvioComponent* Component) override;
 	virtual void Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
+	void Initialize(UVitruvioComponent* Component, UStaticMesh* StaticMesh);
 	virtual bool CanConstructFrom(AActor* Owner) const override;
 	virtual void SetHidden(bool bHidden) override;
 
@@ -179,6 +180,7 @@ public:
 
 	virtual void Initialize(UVitruvioComponent* Component) override;
 	virtual void Initialize(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
+	void Initialize(UVitruvioComponent* Component, const TArray<FSplinePoint>& SplinePoints);
 	virtual bool CanConstructFrom(AActor* Owner) const override;
 
 #if WITH_EDITOR

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioActor.h
@@ -30,11 +30,4 @@ public:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Vitruvio")
 	UVitruvioComponent* VitruvioComponent;
-
-	virtual void Tick(float DeltaSeconds) override;
-	virtual bool ShouldTickIfViewportsOnly() const override;
-	void Initialize();
-
-private:
-	bool bInitialized = false;
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
@@ -1,0 +1,60 @@
+/* Copyright 2021 Esri
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RulePackage.h"
+#include "VitruvioActor.h"
+
+#include "VitruvioBlueprintLibrary.generated.h"
+
+UCLASS()
+class UVitruvioBlueprintLibrary : public UBlueprintFunctionLibrary
+
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Returns all Actors attached to the given Actor which are viable to be converted to VitruvioActors.
+	 *
+	 * @param Root the root actor whose children are checked if they are viable Vitruvio Actors.
+	 * @return all Actors attached to the given Actor which are viable to be converted to VitruvioActors.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	static VITRUVIO_API TArray<AActor*> GetViableVitruvioActorsInHierarchy(AActor* Root);
+
+	/**
+	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (according to
+	 * CanConvertToVitruvioActor) it will be ignored.
+	 *
+	 * @param Actors the Actors to convert to VitruvioActors
+	 * @param Rpk the optional RulePackage
+	 * @return the converted VitruvioActors
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	static VITRUVIO_API TArray<AVitruvioActor*> ConvertToVitruvioActor(const TArray<AActor*>& Actors, URulePackage* Rpk = nullptr);
+
+	/**
+	 * Returns whether the given Actor can be converted to a VitruvioActor (see also ConvertToVitruvioActor). Converting an Actor to a VitruvioActor
+	 * is only possible if the Actor already has a valid initial shape component attached (eg. a StaticMeshComponent).
+	 *
+	 * @param Actor the Actor to test
+	 * @return whether the given Actor can be converted to a VitruvioActor
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	static VITRUVIO_API bool CanConvertToVitruvioActor(AActor* Actor);
+};

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
@@ -38,17 +38,6 @@ public:
 	static VITRUVIO_API TArray<AActor*> GetViableVitruvioActorsInHierarchy(AActor* Root);
 
 	/**
-	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (according to
-	 * CanConvertToVitruvioActor) it will be ignored.
-	 *
-	 * @param Actors the Actors to convert to VitruvioActors
-	 * @param Rpk the optional RulePackage
-	 * @return the converted VitruvioActors
-	 */
-	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	static VITRUVIO_API TArray<AVitruvioActor*> ConvertToVitruvioActor(const TArray<AActor*>& Actors, URulePackage* Rpk = nullptr);
-
-	/**
 	 * Returns whether the given Actor can be converted to a VitruvioActor (see also ConvertToVitruvioActor). Converting an Actor to a VitruvioActor
 	 * is only possible if the Actor already has a valid initial shape component attached (eg. a StaticMeshComponent).
 	 *

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
@@ -16,9 +16,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "RulePackage.h"
 #include "VitruvioActor.h"
-#include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "VitruvioBlueprintLibrary.generated.h"
 
@@ -40,7 +40,8 @@ public:
 
 	/**
 	 * Returns whether the given Actor can be converted to a VitruvioActor (see also ConvertToVitruvioActor). Converting an Actor to a VitruvioActor
-	 * is only possible if the Actor already has a valid initial shape component attached (eg. a StaticMeshComponent).
+	 * is only possible if the Actor has a valid initial shape component attached (eg. a StaticMeshComponent) and does not already
+	 * have a VitruvioComponent attached.
 	 *
 	 * @param Actor the Actor to test
 	 * @return whether the given Actor can be converted to a VitruvioActor

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBlueprintLibrary.h
@@ -18,6 +18,7 @@
 #include "CoreMinimal.h"
 #include "RulePackage.h"
 #include "VitruvioActor.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "VitruvioBlueprintLibrary.generated.h"
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -328,10 +328,6 @@ public:
 	DECLARE_MULTICAST_DELEGATE_TwoParams(FOnAttributesChanged, UObject*, struct FPropertyChangedEvent&);
 	static FOnAttributesChanged OnAttributesChanged;
 
-	virtual void PostLoad() override;
-
-	virtual void OnComponentCreated() override;
-
 	void LoadInitialShape();
 
 	virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -168,6 +168,19 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	bool GetFloatAttribute(const FString& Name, float& OutValue) const;
 
+	/**
+	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * The type of the attribute will be deduced from its string representation: <br>
+	 * "1.0" for the float 1.0 <br>
+	 * "hello" for the string "hello" and <br>
+	 * "true" for the bool true <br>
+	 *
+	 * @param NewAttributes the attributes to be set
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	void SetAttributes(const TMap<FString, FString>& NewAttributes);
+
 	/** Returns the attributes used for generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	const TMap<FString, URuleAttribute*>& GetAttributes() const;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -132,9 +132,9 @@ public:
 							UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access String attribute values used for generation.
+	 * Access string attribute values used for generation.
 	 *
-	 * @param Name The name of the float attribute.
+	 * @param Name The name of the string attribute.
 	 * @param OutValue Set to the attributes value if it exists or to an empty String otherwise.
 	 * @returns True if the String attribute with the given Name exists or false otherwise.
 	 */

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -301,6 +301,9 @@ public:
 	/* Removes the generated meshes from this VitruvioComponent. */
 	void RemoveGeneratedMeshes();
 
+	/* Returns whether the attributes are ready. */
+	bool GetAttributesReady();
+
 	/**
 	 * Evaluate rule attributes.
 	 *

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -249,6 +249,17 @@ public:
 	 */
 	void EvaluateRuleAttributes(bool ForceRegenerate = false, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerateCompletedDelegate);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttributesEvaluatedDelegate);
+
+	/** Called after attributes have been evaluated. */
+	UPROPERTY(BlueprintAssignable, Category = "Vitruvio")
+	FOnAttributesEvaluatedDelegate OnAttributesEvaluated;
+
+	/** Called after generate has completed. */
+	UPROPERTY(BlueprintAssignable, Category = "Vitruvio")
+	FGenerateCompletedDelegate OnGenerateCompleted;
+
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnHierarchyChanged, UVitruvioComponent*);
 	static FOnHierarchyChanged OnHierarchyChanged;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -111,10 +111,11 @@ public:
 	 *
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	bool SetStringAttribute(const FString& Name, const FString& Value);
+	void SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting = false);
 
 	/**
 	 * Access String attribute values used for generation.
@@ -132,10 +133,11 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	bool SetBoolAttribute(const FString& Name, bool Value);
+	void SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting = false);
 
 	/**
 	 * Access bool attribute values used for generation.
@@ -153,10 +155,11 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	bool SetFloatAttribute(const FString& Name, float Value);
+	void SetFloatAttribute(const FString& Name, float Value, bool bAddIfNonExisting = false);
 
 	/**
 	 * Access float attribute values used for generation.
@@ -177,9 +180,10 @@ public:
 	 * "true" for the bool true <br>
 	 *
 	 * @param NewAttributes the attributes to be set
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	void SetAttributes(const TMap<FString, FString>& NewAttributes);
+	void SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting = false);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -142,6 +142,29 @@ public:
 	bool GetStringAttribute(const FString& Name, FString& OutValue) const;
 
 	/**
+	 * Sets the string array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bAddIfNonExisting = false,
+								 UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+
+	/**
+	 * Access string array attribute values used for generation.
+	 *
+	 * @param Name The name of the string attribute.
+	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
+	 * @returns true if the string array attribute with the given Name exists or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	bool GetStringArrayAttribute(const FString& Name, TArray<FString>& OutValue) const;
+
+	/**
 	 * Sets bool attributes used for generation.
 	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
 	 *
@@ -162,6 +185,29 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	bool GetBoolAttribute(const FString& Name, bool& OutValue) const;
+
+	/**
+	 * Sets the bool array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bAddIfNonExisting = false,
+							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+
+	/**
+	 * Access bool array attribute values used for generation.
+	 *
+	 * @param Name The name of the bool attribute.
+	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
+	 * @returns true if the bool array attribute with the given Name exists or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	bool GetBoolArrayAttribute(const FString& Name, TArray<bool>& OutValue) const;
 
 	/**
 	 * Sets float attributes used for generation.
@@ -185,6 +231,29 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	bool GetFloatAttribute(const FString& Name, double& OutValue) const;
+
+	/**
+	 * Sets the float array attribute with the given name.
+	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 *
+	 * @param Name The name of the attribute.
+	 * @param Values The new values for the attribute.
+	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
+	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
+	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 */
+	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bAddIfNonExisting = false,
+								UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+
+	/**
+	 * Access float array attribute values used for generation.
+	 *
+	 * @param Name The name of the float attribute.
+	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
+	 * @returns true if the float array attribute with the given Name exists or false otherwise.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	bool GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const;
 
 	/**
 	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -122,11 +122,9 @@ public:
 	 *
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
 	 * @param CallbackProxy The callback proxy used to register for completion events.
 	 */
-	void SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting = false,
-							UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetStringAttribute(const FString& Name, const FString& Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the string attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -143,12 +141,10 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bAddIfNonExisting = false,
-								 UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the string array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -165,11 +161,10 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting = false, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetBoolAttribute(const FString& Name, bool Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the bool attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -186,12 +181,10 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bAddIfNonExisting = false,
-							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the bool array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -208,12 +201,10 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatAttribute(const FString& Name, double Value, bool bAddIfNonExisting = false,
-						   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetFloatAttribute(const FString& Name, double Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the float attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -230,12 +221,10 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bAddIfNonExisting = false,
-								UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the float array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -254,11 +243,9 @@ public:
 	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
 	 *
 	 * @param NewAttributes The attributes to be sets
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetAttributes(const TMap<FString, FString>& NewAttributes, bool bAddIfNonExisting = false,
-					   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetAttributes(const TMap<FString, FString>& NewAttributes, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -107,7 +107,7 @@ public:
 	/**
 	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
 	 */
-	void SetRpk(URulePackage* RulePackage, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetRpk(URulePackage* RulePackage, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/** Returns true if the component has valid input data (initial shape and Rule Package). */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
@@ -122,9 +122,11 @@ public:
 	 *
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The callback proxy used to register for completion events.
 	 */
-	void SetStringAttribute(const FString& Name, const FString& Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetStringAttribute(const FString& Name, const FString& Value, bool bGenerateModel = true,
+							UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the string attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -141,10 +143,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bGenerateModel = true,
+								 UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the string array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -161,10 +165,11 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolAttribute(const FString& Name, bool Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetBoolAttribute(const FString& Name, bool Value, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the bool attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -181,10 +186,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bGenerateModel = true,
+							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the bool array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -201,10 +208,11 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatAttribute(const FString& Name, double Value, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetFloatAttribute(const FString& Name, double Value, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the float attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -221,10 +229,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bGenerateModel = true,
+								UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the float array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -243,25 +253,30 @@ public:
 	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
 	 *
 	 * @param NewAttributes The attributes to be sets
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetAttributes(const TMap<FString, FString>& NewAttributes, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetAttributes(const TMap<FString, FString>& NewAttributes, bool bGenerateModel = true,
+					   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.
 	 *
 	 * @param StaticMesh the new initial shape static mesh.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetMeshInitialShape(UStaticMesh* StaticMesh, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetMeshInitialShape(UStaticMesh* StaticMesh, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given spline points as initial shape. Regenerates the model if generate automatically is set to true.
 	 *
 	 * @param SplinePoints the new initial shape spline points.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel = true,
+							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/** Returns the attributes used for generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
@@ -274,13 +289,11 @@ public:
 	/** Returns the reports created during generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	const TMap<FString, FReport>& GetReports() const;
-		
+
 	/**
 	 * Sets the random seed used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	void SetRandomSeed(int32 NewRandomSeed);
+	void SetRandomSeed(int32 NewRandomSeed, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/* Initialize the VitruvioComponent. Only needs to be called if the Component is natively attached. */
 	void Initialize();
@@ -351,7 +364,7 @@ private:
 
 	UPROPERTY(Transient)
 	bool bInitialized = false;
-	
+
 	bool bInGenerateCallback = false;
 
 	TQueue<FGenerateQueueItem> GenerateQueue;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -99,18 +99,17 @@ public:
 	bool GenerateCollision = true;
 
 	/**
-	 * Generates a model using the current RPK and initial shapes. If attributes are not loaded yet they will first be evaluated. If no Initial Shape
-	 * or RPK is set this method will do nothing.
+	 * Generates a model using the current Rule Package and initial shape. If the attributes are not yet available, they will first be evaluated. If
+	 * no Initial Shape or Rule Package is set, this method will do nothing.
 	 */
 	void Generate(UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Sets the given Rpk and possibly invalidates already loaded attributes. This will trigger a reevaluation of the attributes and if
-	 * GenerateAutomatically is set to true also regenerates the the model.
+	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
 	 */
 	void SetRpk(URulePackage* RulePackage, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
-	/** Returns true if the component has valid input data (initial shape and RPK). */
+	/** Returns true if the component has valid input data (initial shape and Rule Package). */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	bool HasValidInputData() const;
 
@@ -119,20 +118,18 @@ public:
 	bool IsReadyToGenerate() const;
 
 	/**
-	 * Sets string attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the string attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
-	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
-	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
-	 * @returns true if the attribute has been set to the new value or false otherwise.
+	 * @param bAddIfNonExisting Adds a new attribute if the no attribute is found with the given Name.
+	 * @param CallbackProxy The callback proxy used to register for completion events.
 	 */
 	void SetStringAttribute(const FString& Name, const FString& Value, bool bAddIfNonExisting = false,
 							UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access string attribute values used for generation.
+	 * Access the string attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the string attribute.
 	 * @param OutValue Set to the attributes value if it exists or to an empty String otherwise.
@@ -142,8 +139,7 @@ public:
 	bool GetStringAttribute(const FString& Name, FString& OutValue) const;
 
 	/**
-	 * Sets the string array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the string array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -155,7 +151,7 @@ public:
 								 UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access string array attribute values used for generation.
+	 * Access the string array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the string attribute.
 	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
@@ -165,8 +161,7 @@ public:
 	bool GetStringArrayAttribute(const FString& Name, TArray<FString>& OutValue) const;
 
 	/**
-	 * Sets bool attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
@@ -177,18 +172,17 @@ public:
 	void SetBoolAttribute(const FString& Name, bool Value, bool bAddIfNonExisting = false, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access bool attribute values used for generation.
+	 * Access the bool attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the bool attribute.
 	 * @param OutValue Set to the attributes value if it exists or to false otherwise.
-	 * @returns true if the float attribute with the given Name exists or false otherwise.
+	 * @returns true if the bool attribute with the given Name exists or false otherwise.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	bool GetBoolAttribute(const FString& Name, bool& OutValue) const;
 
 	/**
-	 * Sets the bool array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the bool array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -200,7 +194,7 @@ public:
 							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access bool array attribute values used for generation.
+	 * Access the bool array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the bool attribute.
 	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
@@ -210,8 +204,7 @@ public:
 	bool GetBoolArrayAttribute(const FString& Name, TArray<bool>& OutValue) const;
 
 	/**
-	 * Sets float attributes used for generation.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the float attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
@@ -223,7 +216,7 @@ public:
 						   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access float attribute values used for generation.
+	 * Access the float attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the float attribute.
 	 * @param OutValue Set to the attributes value if it exists or to 0.0f otherwise.
@@ -233,8 +226,7 @@ public:
 	bool GetFloatAttribute(const FString& Name, double& OutValue) const;
 
 	/**
-	 * Sets the float array attribute with the given name.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
+	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -246,7 +238,7 @@ public:
 								UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Access float array attribute values used for generation.
+	 * Access the float array attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
 	 *
 	 * @param Name The name of the float attribute.
 	 * @param OutValue Set to the array attribute value if it exists or an empty array otherwise.
@@ -256,14 +248,12 @@ public:
 	bool GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const;
 
 	/**
-	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.
-	 * If GenerateAutomatically is set to true this will automatically trigger a regeneration.
-	 * The type of the attribute will be deduced from its string representation: <br>
-	 * "1.0" for the float 1.0 <br>
-	 * "hello" for the string "hello" and <br>
-	 * "true" for the bool true <br>
+	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
+	 * attributes, the key-value pair will be ignored. If bAddIfNonExisting is set to true, new attributes will be added in case they are not found in
+	 * the current attributes. Regenerates the model if GenerateAutomatically is set to true. The type of the attribute will be deduced from its
+	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
 	 *
-	 * @param NewAttributes the attributes to be set
+	 * @param NewAttributes The attributes to be sets
 	 * @param bAddIfNonExisting Adds a new Attribute if the no Attribute is found with the given Name.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
@@ -325,7 +315,7 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "Vitruvio")
 	FOnAttributesEvaluatedDelegate OnAttributesEvaluated;
 
-	/** Called after generate has completed. */
+	/** Called after a model generation has completed. */
 	UPROPERTY(BlueprintAssignable, Category = "Vitruvio")
 	FGenerateCompletedDelegate OnGenerateCompleted;
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -173,7 +173,7 @@ public:
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatAttribute(const FString& Name, float Value, bool bAddIfNonExisting = false,
+	void SetFloatAttribute(const FString& Name, double Value, bool bAddIfNonExisting = false,
 						   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
@@ -184,7 +184,7 @@ public:
 	 * @returns true if the float attribute with the given Name exists or false otherwise.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	bool GetFloatAttribute(const FString& Name, float& OutValue) const;
+	bool GetFloatAttribute(const FString& Name, double& OutValue) const;
 
 	/**
 	 * Sets the given attributes. If a key does not exist in the current attribute map the key-value pair will be ignored.

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -181,6 +181,22 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	void SetAttributes(const TMap<FString, FString>& NewAttributes);
 
+	/**
+	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.
+	 *
+	 * @param StaticMesh the new initial shape static mesh.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	void SetMeshInitialShape(UStaticMesh* StaticMesh);
+
+	/**
+	 * Sets the given spline points as initial shape. Regenerates the model if generate automatically is set to true.
+	 *
+	 * @param SplinePoints the new initial shape spline points.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
+	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints);
+
 	/** Returns the attributes used for generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	const TMap<FString, URuleAttribute*>& GetAttributes() const;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -362,6 +362,9 @@ private:
 	UPROPERTY(VisibleAnywhere, DisplayName = "Reports", Category = "Vitruvio")
 	TMap<FString, FReport> Reports;
 
+	UPROPERTY(Transient)
+	bool bInitialized = false;
+	
 	bool bInGenerateCallback = false;
 
 	TQueue<FGenerateQueueItem> GenerateQueue;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -105,7 +105,7 @@ public:
 	void Generate(UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Sets the given Rule Package. This will reevaluate the attributes and if GenerateAutomatically is set to true, also regenerates the model.
+	 * Sets the given Rule Package. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
 	void SetRpk(URulePackage* RulePackage, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
@@ -139,7 +139,7 @@ public:
 	bool GetStringAttribute(const FString& Name, FString& OutValue) const;
 
 	/**
-	 * Sets the string array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the string array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -161,7 +161,7 @@ public:
 	bool GetStringArrayAttribute(const FString& Name, TArray<FString>& OutValue) const;
 
 	/**
-	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
@@ -182,7 +182,7 @@ public:
 	bool GetBoolAttribute(const FString& Name, bool& OutValue) const;
 
 	/**
-	 * Sets the bool array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the bool array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -204,7 +204,7 @@ public:
 	bool GetBoolArrayAttribute(const FString& Name, TArray<bool>& OutValue) const;
 
 	/**
-	 * Sets the float attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the float attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
@@ -225,7 +225,7 @@ public:
 	bool GetFloatAttribute(const FString& Name, double& OutValue) const;
 
 	/**
-	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
@@ -247,12 +247,12 @@ public:
 	bool GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const;
 
 	/**
-	 * Sets the given scalar attributes. If bAddIfNonExisting is set to false and a given key from the NewAttributes is not found in the current
-	 * attributes, the key-value pair will be ignored. If bAddIfNonExisting is set to true, new attributes will be added in case they are not found in
-	 * the current attributes. Regenerates the model if GenerateAutomatically is set to true. The type of the attribute will be deduced from its
+	 * Sets the given attributes. If a key from the NewAttributes is not found in the current attributes, the key-value pair will be ignored.
+	 * Regenerates the model if bGenerateModel is set to true. The type of the attribute will be deduced from its
 	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
+	 * array values are separated via a comma eg: "1.3,4.5,0" for a float array with the values 1.3, 4.5 and 0.
 	 *
-	 * @param NewAttributes The attributes to be sets
+	 * @param NewAttributes The attributes to be set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
@@ -260,7 +260,7 @@ public:
 					   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Sets the given static mesh as initial shape. Regenerates the model if generate automatically is set to true.
+	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param StaticMesh the new initial shape static mesh.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
@@ -269,7 +269,7 @@ public:
 	void SetMeshInitialShape(UStaticMesh* StaticMesh, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
-	 * Sets the given spline points as initial shape. Regenerates the model if generate automatically is set to true.
+	 * Sets the given spline points as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param SplinePoints the new initial shape spline points.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
@@ -291,7 +291,7 @@ public:
 	const TMap<FString, FReport>& GetReports() const;
 
 	/**
-	 * Sets the random seed used for generation.
+	 * Sets the random seed used for generation. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
 	void SetRandomSeed(int32 NewRandomSeed, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "AttributeMap.h"
+#include "GenerateCompletedCallbackProxy.h"
 #include "InitialShape.h"
 #include "MeshCache.h"
 #include "MeshDescription.h"
@@ -69,36 +70,10 @@ private:
 
 class FEvalAttributesToken : public FInvalidationToken
 {
-public:
-	void RequestReEvaluateAttributes()
-	{
-		bRequestReEvaluateAttributes = true;
-	}
-
-	bool IsReEvaluateRequested() const
-	{
-		return bRequestReEvaluateAttributes;
-	}
-
-private:
-	FThreadSafeBool bRequestReEvaluateAttributes = false;
 };
 
 class FGenerateToken : public FInvalidationToken
 {
-public:
-	void RequestRegenerate()
-	{
-		bRequestRegenerate = true;
-	}
-
-	bool IsRegenerateRequested() const
-	{
-		return bRequestRegenerate;
-	}
-
-private:
-	FThreadSafeBool bRequestRegenerate = false;
 };
 
 template <typename R, typename T>
@@ -156,8 +131,8 @@ public:
 	 * \param RandomSeed
 	 * \return the generated UStaticMesh.
 	 */
-	VITRUVIO_API FGenerateResultDescription Generate(const FInitialShapePolygon& InitialShape, URulePackage* RulePackage,
-													 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
+	VITRUVIO_API FGenerateResultDescription Generate(const FInitialShapePolygon& InitialShape, URulePackage* RulePackage, AttributeMapUPtr Attributes,
+													 const int32 RandomSeed) const;
 
 	/**
 	 * \brief Asynchronously evaluates attributes for the given initial shape and rule package.
@@ -169,7 +144,7 @@ public:
 	 * \return
 	 */
 	VITRUVIO_API FAttributeMapResult EvaluateRuleAttributesAsync(const FInitialShapePolygon& InitialShape, URulePackage* RulePackage,
-															 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
+																 AttributeMapUPtr Attributes, const int32 RandomSeed) const;
 
 	/**
 	 * \return whether PRT is initialized meaning installed and ready to use. Before initialization generation is not possible and will

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -20,6 +20,7 @@
 
 #include "Algo/Transform.h"
 #include "Brushes/SlateColorBrush.h"
+#include "HAL/PlatformApplicationMisc.h"
 #include "IDetailGroup.h"
 #include "IDetailTreeNode.h"
 #include "IPropertyRowGenerator.h"
@@ -372,6 +373,20 @@ TSharedPtr<SWidget> CreateStringAttributeWidget(A* Attribute, const TSharedPtr<I
 	}
 }
 
+void AddCopyNameToClipboardAction(FDetailWidgetRow& Row, URuleAttribute* Attribute)
+{
+	// clang-format off
+	Row.AddCustomContextMenuAction(FUIAction(FExecuteAction::CreateLambda([Attribute]() {
+		   if (Attribute)
+		   {
+			   FPlatformApplicationMisc::ClipboardCopy(*Attribute->Name);
+		   }
+	   })),
+	   FText::FromString(TEXT("Copy Fully Qualified Attribute Name")),
+	   FText::FromString(TEXT("Copies the fully qualified attribute name to the clipboard.")));
+	// clang-format on
+}
+
 void AddScalarWidget(const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes, IDetailGroup& Group, URuleAttribute* Attribute,
 					 UVitruvioComponent* VitruvioActor)
 {
@@ -389,6 +404,8 @@ void AddScalarWidget(const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes, 
 	IDetailPropertyRow& DetailPropertyRow = Group.AddPropertyRow(PropertyHandle.ToSharedRef());
 	DetailPropertyRow.OverrideResetToDefault(ResetToDefaultOverride(Attribute, VitruvioActor));
 	FDetailWidgetRow& ValueRow = DetailPropertyRow.CustomWidget();
+
+	AddCopyNameToClipboardAction(ValueRow, Attribute);
 
 	PropertyHandle->SetPropertyDisplayName(FText::FromString(Attribute->DisplayName));
 	TSharedPtr<SWidget> NameWidget;
@@ -437,6 +454,8 @@ void AddArrayWidget(const TArray<TSharedRef<IDetailTreeNode>> DetailTreeNodes, I
 		FString ArrayGroupKey = Attribute->ImportPath + TEXT(".") + Attribute->Name;
 		IDetailGroup& ArrayHeader = Group.AddGroup(*ArrayGroupKey, FText::GetEmpty());
 		FDetailWidgetRow& Row = ArrayHeader.HeaderRow();
+
+		AddCopyNameToClipboardAction(Row, Attribute);
 		HeaderPropertyRow->OverrideResetToDefault(ResetToDefaultOverride(Attribute, VitruvioActor));
 
 		FDetailWidgetRow DefaultWidgetsRow;

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -74,7 +74,7 @@ bool HasAnyVitruvioActor(TArray<AActor*> Actors)
 	});
 }
 
-TArray<AActor*> GetViableVitruvioActorsInHiararchy(AActor* Root)
+TArray<AActor*> GetViableVitruvioActorsInHierarchy(AActor* Root)
 {
 	TArray<AActor*> ViableActors;
 	if (CanConvertToVitruvioActor(Root))
@@ -90,7 +90,7 @@ TArray<AActor*> GetViableVitruvioActorsInHiararchy(AActor* Root)
 
 		for (AActor* Child : ChildActors)
 		{
-			ViableActors.Append(GetViableVitruvioActorsInHiararchy(Child));
+			ViableActors.Append(GetViableVitruvioActorsInHierarchy(Child));
 		}
 	}
 
@@ -145,7 +145,7 @@ void SelectAllViableVitruvioActors(TArray<AActor*> Actors)
 	GEditor->SelectNone(false, true, false);
 	for (AActor* SelectedActor : Actors)
 	{
-		TArray<AActor*> NewSelection = GetViableVitruvioActorsInHiararchy(SelectedActor);
+		TArray<AActor*> NewSelection = GetViableVitruvioActorsInHierarchy(SelectedActor);
 		for (AActor* ActorToSelect : NewSelection)
 		{
 			GEditor->SelectActor(ActorToSelect, true, false);

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -57,7 +57,8 @@ void AssignRulePackage(TArray<AActor*> Actors)
 
 	if (SelectedRpk.IsSet())
 	{
-		UVitruvioBlueprintLibrary::ConvertToVitruvioActor(Actors, SelectedRpk.GetValue());
+		TArray<AVitruvioActor*> ConvertedActors;
+		UGenerateCompletedCallbackProxy::ConvertToVitruvioActor(Actors, ConvertedActors, SelectedRpk.GetValue());
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -105,7 +105,6 @@ void AssignRulePackage(TArray<AActor*> Actors)
 	{
 		URulePackage* Rpk = SelectedRpk.GetValue();
 
-		UVitruvioComponent* Component = nullptr;
 		for (AActor* Actor : Actors)
 		{
 			AActor* OldAttachParent = Actor->GetAttachParentActor();

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -30,6 +30,7 @@
 #include "IAssetTools.h"
 #include "Modules/ModuleManager.h"
 #include "VitruvioStyle.h"
+#include "VitruvioBlueprintLibrary.h"
 #include "Widgets/Notifications/SNotificationList.h"
 
 #define LOCTEXT_NAMESPACE "VitruvioEditorModule"
@@ -37,33 +38,9 @@
 namespace
 {
 
-bool CanConvertToVitruvioActor(AActor* Actor)
-{
-
-	if (Cast<AVitruvioActor>(Actor))
-	{
-		return false;
-	}
-
-	if (Actor->GetComponentByClass(UVitruvioComponent::StaticClass()))
-	{
-		return false;
-	}
-
-	for (const auto& InitialShapeClasses : UVitruvioComponent::GetInitialShapesClasses())
-	{
-		UInitialShape* DefaultInitialShape = Cast<UInitialShape>(InitialShapeClasses->GetDefaultObject());
-		if (DefaultInitialShape && DefaultInitialShape->CanConstructFrom(Actor))
-		{
-			return true;
-		}
-	}
-	return false;
-}
-
 bool HasAnyViableVitruvioActor(TArray<AActor*> Actors)
 {
-	return Algo::AllOf(Actors, [](AActor* In) { return CanConvertToVitruvioActor(In); });
+	return Algo::AllOf(Actors, [](AActor* In) { return UVitruvioBlueprintLibrary::CanConvertToVitruvioActor(In); });
 }
 
 bool HasAnyVitruvioActor(TArray<AActor*> Actors)
@@ -74,68 +51,13 @@ bool HasAnyVitruvioActor(TArray<AActor*> Actors)
 	});
 }
 
-TArray<AActor*> GetViableVitruvioActorsInHierarchy(AActor* Root)
-{
-	TArray<AActor*> ViableActors;
-	if (CanConvertToVitruvioActor(Root))
-	{
-		ViableActors.Add(Root);
-	}
-
-	// If the actor has a VitruvioComponent attached we do not further check its children.
-	if (Root->FindComponentByClass<UVitruvioComponent>() == nullptr)
-	{
-		TArray<AActor*> ChildActors;
-		Root->GetAttachedActors(ChildActors);
-
-		for (AActor* Child : ChildActors)
-		{
-			ViableActors.Append(GetViableVitruvioActorsInHierarchy(Child));
-		}
-	}
-
-	return ViableActors;
-}
-
 void AssignRulePackage(TArray<AActor*> Actors)
 {
 	TOptional<URulePackage*> SelectedRpk = FChooseRulePackageDialog::OpenDialog();
 
 	if (SelectedRpk.IsSet())
 	{
-		URulePackage* Rpk = SelectedRpk.GetValue();
-
-		for (AActor* Actor : Actors)
-		{
-			AActor* OldAttachParent = Actor->GetAttachParentActor();
-			if (Actor->IsA<AStaticMeshActor>())
-			{
-				AVitruvioActor* VitruvioActor = Actor->GetWorld()->SpawnActor<AVitruvioActor>(Actor->GetActorLocation(), Actor->GetActorRotation());
-
-				UStaticMeshComponent* OldStaticMeshComponent = Actor->FindComponentByClass<UStaticMeshComponent>();
-
-				UStaticMeshComponent* NewStaticMeshComponent = NewObject<UStaticMeshComponent>(VitruvioActor, TEXT("InitialShapeStaticMesh"));
-				NewStaticMeshComponent->Mobility = EComponentMobility::Movable;
-				NewStaticMeshComponent->SetStaticMesh(OldStaticMeshComponent->GetStaticMesh());
-				NewStaticMeshComponent->SetWorldTransform(VitruvioActor->GetTransform());
-				VitruvioActor->AddInstanceComponent(NewStaticMeshComponent);
-				NewStaticMeshComponent->AttachToComponent(VitruvioActor->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
-				NewStaticMeshComponent->OnComponentCreated();
-				NewStaticMeshComponent->RegisterComponent();
-
-				UVitruvioComponent* VitruvioComponent = VitruvioActor->VitruvioComponent;
-				VitruvioComponent->SetRpk(Rpk);
-
-				VitruvioActor->Initialize();
-
-				if (OldAttachParent)
-				{
-					VitruvioActor->AttachToActor(OldAttachParent, FAttachmentTransformRules::KeepWorldTransform);
-				}
-
-				Actor->Destroy();
-			}
-		}
+		UVitruvioBlueprintLibrary::ConvertToVitruvioActor(Actors, SelectedRpk.GetValue());
 	}
 }
 
@@ -144,7 +66,7 @@ void SelectAllViableVitruvioActors(TArray<AActor*> Actors)
 	GEditor->SelectNone(false, true, false);
 	for (AActor* SelectedActor : Actors)
 	{
-		TArray<AActor*> NewSelection = GetViableVitruvioActorsInHierarchy(SelectedActor);
+		TArray<AActor*> NewSelection = UVitruvioBlueprintLibrary::GetViableVitruvioActorsInHierarchy(SelectedActor);
 		for (AActor* ActorToSelect : NewSelection)
 		{
 			GEditor->SelectActor(ActorToSelect, true, false);

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioEditorModule.cpp
@@ -53,12 +53,17 @@ bool HasAnyVitruvioActor(TArray<AActor*> Actors)
 
 void AssignRulePackage(TArray<AActor*> Actors)
 {
+	if (Actors.Num() == 0)
+	{
+		return;
+	}
+
 	TOptional<URulePackage*> SelectedRpk = FChooseRulePackageDialog::OpenDialog();
 
 	if (SelectedRpk.IsSet())
 	{
 		TArray<AVitruvioActor*> ConvertedActors;
-		UGenerateCompletedCallbackProxy::ConvertToVitruvioActor(Actors, ConvertedActors, SelectedRpk.GetValue());
+		UGenerateCompletedCallbackProxy::ConvertToVitruvioActor(Actors[0], Actors, ConvertedActors, SelectedRpk.GetValue());
 	}
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/VitruvioEditor.Build.cs
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/VitruvioEditor.Build.cs
@@ -26,6 +26,7 @@ public class VitruvioEditor : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
+			    "ApplicationCore",
 				"Core",
 				"CoreUObject",
 				"Engine",


### PR DESCRIPTION
- Added Blueprint support to:
  - Change the Initial Shape (Spline or StaticMesh) of a VitruvioComponent
  - Convert a StaticMeshActor to a VitruvioActor
  - Set array attribute on a VitruvioComponent
- Added async support of VitruvioComponent modifications. The Blueprint functions have callbacks when the generate/rule evaluation has completed (eg when changing an attribute). This is helpful to properly chain together several Blueprint calls.
- Added a copy fully qualified attribute name to the details panel
- Fixed some minor issues and typos