### PR TITLE
Fix float attribute editor crash

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Private/VitruvioComponentDetails.cpp
@@ -232,7 +232,10 @@ TSharedPtr<SSpinBox<double>> CreateNumericInputWidget(Attr* Attribute, TSharedPt
 	auto Annotation = Attribute->GetRangeAnnotation();
 
 	auto OnValueCommit = [FloatProperty](double Value, ETextCommit::Type Type) {
-		FloatProperty->SetValue(Value);
+		if (FloatProperty->GetPropertyNode().IsValid())
+		{
+			FloatProperty->SetValue(Value);
+		}
 	};
 
 	// clang-format off


### PR DESCRIPTION
After pressing enter in a float editor the value is committed the model is regenerated and then the attribute editor is rebuilt. This causes a focus lost event on the old editor widget which also commits the value, but at this point the underlying property is not valid anymore which caused a segmentation fault.