### PR TITLE
Don't save generated static meshes

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -265,6 +265,19 @@ bool IsDefaultInitialShape(const FInitialShapePolygon& InitialShapePolygon)
 	return false;
 }
 
+void BuildMesh(const TArray<const FMeshDescription*>& MeshDescriptions, UStaticMesh* StaticMesh)
+{
+	UStaticMesh::FBuildMeshDescriptionsParams Params;
+	Params.bMarkPackageDirty = false;
+#if !WITH_EDITOR
+	Params.bFastBuild = true;
+#endif
+
+	StaticMesh->BuildFromMeshDescriptions(MeshDescriptions, Params);
+
+	check(StaticMesh->GetRenderData() && StaticMesh->GetRenderData()->IsInitialized());
+}
+
 UStaticMesh* CreateDefaultStaticMesh()
 {
 	UStaticMesh* StaticMesh;
@@ -300,16 +313,7 @@ UStaticMesh* CreateDefaultStaticMesh()
 	StaticMesh = NewObject<UStaticMesh>();
 #endif
 
-	UStaticMesh::FBuildMeshDescriptionsParams Params;
-	Params.bCommitMeshDescription = true;
-	Params.bMarkPackageDirty = false;
-#if !WITH_EDITOR
-	Params.bFastBuild = true;
-#endif
-
-	StaticMesh->BuildFromMeshDescriptions(MeshDescriptions, Params);
-
-	check(StaticMesh->GetRenderData() && StaticMesh->GetRenderData()->IsInitialized());
+	BuildMesh(MeshDescriptions, StaticMesh);
 
 #if WITH_EDITOR
 	const FString PackageFileName = InitialShapeName + FPackageName::GetAssetPackageExtension();
@@ -341,16 +345,7 @@ UStaticMesh* CreateStaticMeshFromInitialShapePolygon(const FInitialShapePolygon&
 	StaticMesh->SetNumSourceModels(MeshDescriptions.Num());
 #endif
 
-	UStaticMesh::FBuildMeshDescriptionsParams Params;
-	Params.bCommitMeshDescription = true;
-	Params.bMarkPackageDirty = false;
-#if !WITH_EDITOR
-	Params.bFastBuild = true;
-#endif
-
-	StaticMesh->BuildFromMeshDescriptions(MeshDescriptions, Params);
-
-	check(StaticMesh->GetRenderData() && StaticMesh->GetRenderData()->IsInitialized());
+	BuildMesh(MeshDescriptions, StaticMesh);
 
 	return StaticMesh;
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -511,7 +511,7 @@ void UVitruvioComponent::LoadInitialShape()
 {
 	if (InitialShape)
 	{
-		InitialShapeSceneComponent = InitialShape->CreateInitialShapeComponent(this, InitialShape->GetPolygon());
+		InitialShapeSceneComponent = InitialShape->CreateInitialShapeComponent(this);
 		return;
 	}
 
@@ -532,6 +532,7 @@ void UVitruvioComponent::LoadInitialShape()
 		InitialShape = NewObject<UInitialShape>(GetOwner(), GetInitialShapesClasses()[0], NAME_None, RF_Transactional);
 	}
 
+	InitialShape->Initialize();
 	InitialShapeSceneComponent = InitialShape->CreateInitialShapeComponent(this);
 	InitialShape->UpdatePolygon(this);
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -132,14 +132,8 @@ public:
 	void SetPolygon(const FInitialShapePolygon& NewPolygon);
 
 	const TArray<FVector3f>& GetVertices() const;
-	virtual void Initialize(UVitruvioComponent* Component);
 	bool IsValid() const;
-
-	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon)
-	{
-		unimplemented();
-		return nullptr;
-	}
+	void Initialize();
 
 	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component)
 	{
@@ -191,7 +185,6 @@ public:
 	GENERATED_BODY()
 
 	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component) override;
-	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
 	USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, UStaticMesh* StaticMesh);
 	virtual void UpdatePolygon(UVitruvioComponent* Component) override;
 	void UpdateSceneComponent(UVitruvioComponent* Component) override;
@@ -204,8 +197,8 @@ public:
 #endif
 
 #if WITH_EDITORONLY_DATA
-	UPROPERTY(EditAnywhere, Category = "Vitruvio", TextExportTransient, Transient, DuplicateTransient)
-	UStaticMesh* InitialShapeMesh;
+	UPROPERTY(EditAnywhere, Category = "Vitruvio")
+	TSoftObjectPtr<UStaticMesh> InitialShapeMesh;
 #endif
 };
 
@@ -219,7 +212,6 @@ public:
 	int32 SplineApproximationPoints = 15;
 
 	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component) override;
-	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon) override;
 	USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const TArray<FSplinePoint>& SplinePoints);
 	virtual void UpdatePolygon(UVitruvioComponent* Component) override;
 	virtual void UpdateSceneComponent(UVitruvioComponent* Component) override;


### PR DESCRIPTION
It does not make sense to save the StaticMesh InitialShapes as assets, since we already serialize the polygon of the InitialShape.

Saving them caused issues when the asset was not in the project anymore for packaged executables. We now just store a SoftReference to the asset to minimize creation of the StaticMesh if the Asset is still available.

Also we need to set the bFastBuild path for non editor builds (asserts otherwise).