### PR TITLE
smenon/edit_multiple_shapes

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -638,10 +638,69 @@ bool UVitruvioComponent::GetFloatArrayAttribute(const FString& Name, TArray<doub
 	return GetAttribute<UFloatArrayAttribute, TArray<double>>(this->Attributes, Name, OutValue);
 }
 
+void UVitruvioComponent::SetAttribute(const FString& Key, const FString& Value, bool bGenerateModel,
+									   UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	URuleAttribute* const* AttributeResult = this->Attributes.Find(Key);
+	if (!AttributeResult)
+	{
+		return;
+	}
+
+	URuleAttribute const* Attribute = *AttributeResult;
+
+	if (Cast<UFloatAttribute>(Attribute))
+	{
+		EvaluateAndSetAttribute<UFloatAttribute, double>(this, this->Attributes, Key, FCString::Atof(*Value), bGenerateModel, CallbackProxy);
+	}
+	else if (Cast<UBoolAttribute>(Attribute))
+	{
+		EvaluateAndSetAttribute<UBoolAttribute, bool>(this, this->Attributes, Key, ToBool(Value), bGenerateModel, CallbackProxy);
+	}
+	else if (Cast<UStringAttribute>(Attribute))
+	{
+		EvaluateAndSetAttribute<UStringAttribute, FString>(this, this->Attributes, Key, Value, bGenerateModel, CallbackProxy);
+	}
+	else if (Cast<UArrayAttribute>(Attribute))
+	{
+		FString ArrayValue = Value;
+		if (Value.StartsWith(TEXT("[")) && Value.EndsWith(TEXT("]")))
+		{
+			ArrayValue = Value.LeftChop(1).RightChop(1);
+		}
+
+		TArray<FString> StringValues;
+		ArrayValue.ParseIntoArray(StringValues, TEXT(","));
+
+		if (Cast<UFloatArrayAttribute>(Attribute))
+		{
+			TArray<double> DoubleValues;
+			Algo::Transform(StringValues, DoubleValues, [](const auto& In) { return FCString::Atof(*In); });
+			EvaluateAndSetAttribute<UFloatArrayAttribute, TArray<double>>(this, this->Attributes, Key, DoubleValues, bGenerateModel, CallbackProxy);
+		}
+		else if (Cast<UBoolArrayAttribute>(Attribute))
+		{
+			TArray<bool> BoolValues;
+			Algo::Transform(StringValues, BoolValues, [](const auto& In) { return ToBool(In); });
+			EvaluateAndSetAttribute<UBoolArrayAttribute, TArray<bool>>(this, this->Attributes, Key, BoolValues, bGenerateModel, CallbackProxy);
+		}
+		else
+		{
+			EvaluateAndSetAttribute<UStringArrayAttribute, TArray<FString>>(this, this->Attributes, Key, StringValues, bGenerateModel, CallbackProxy);
+		}
+	}
+}
+
 void UVitruvioComponent::SetAttributes(const TMap<FString, FString>& NewAttributes, bool bGenerateModel,
 									   UGenerateCompletedCallbackProxy* CallbackProxy)
 {
-	EvaluateAndSetAttributes(this, NewAttributes, bGenerateModel, CallbackProxy);
+	for (const auto& KeyValues : NewAttributes)
+	{
+		const FString& Value = KeyValues.Value;
+		const FString& Key = KeyValues.Key;
+
+		this->SetAttribute(Key, Value, bGenerateModel, CallbackProxy);
+	}
 }
 
 void UVitruvioComponent::SetMeshInitialShape(UStaticMesh* StaticMesh, bool bGenerateModel, UGenerateCompletedCallbackProxy* CallbackProxy)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -336,6 +336,20 @@ public:
 	bool GetFloatArrayAttribute(const FString& Name, TArray<double>& OutValue) const;
 
 	/**
+	 * Sets a given attribute. If a key with the provided name is not found in the current attributes, the key-value pair will be ignored.
+	 * Regenerates the model if bGenerateModel is set to true. The type of the attribute will be deduced from its
+	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>
+	 * array values are separated via a comma eg: "1.3,4.5,0" for a float array with the values 1.3, 4.5 and 0.
+	 *
+	 * @param Key The name of the attribute to be changed.
+	 * @param Value The updated/changed value for the attribute.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
+	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
+	 */
+	void SetAttribute(const FString& Key, const FString& Value, bool bGenerateModel = true,
+					   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+
+	/**
 	 * Sets the given attributes. If a key from the NewAttributes is not found in the current attributes, the key-value pair will be ignored.
 	 * Regenerates the model if bGenerateModel is set to true. The type of the attribute will be deduced from its
 	 * string representation: <br> "1.0" for the float 1.0 <br> "hello" for the string "hello" and <br> "true" for the bool true <br>

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
@@ -45,6 +45,7 @@ private:
 	void BuildAttributeEditor(IDetailLayoutBuilder& DetailBuilder, IDetailCategoryBuilder& RootCategory, UVitruvioComponent* VitruvioActor);
 
 	TArray<TWeakObjectPtr<UObject>> ObjectsBeingCustomized;
+	TArray<UVitruvioComponent*> VitruvioComponentsSelected;
 	TWeakPtr<IDetailLayoutBuilder> CachedDetailBuilder;
 	TSharedPtr<SWidget> ColorPickerParentWidget;
 	TSharedPtr<STextComboBox> ChangeInitialShapeCombo;

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
@@ -45,7 +45,7 @@ private:
 	void BuildAttributeEditor(IDetailLayoutBuilder& DetailBuilder, IDetailCategoryBuilder& RootCategory, UVitruvioComponent* VitruvioActor);
 
 	TArray<TWeakObjectPtr<UObject>> ObjectsBeingCustomized;
-	TArray<UVitruvioComponent*> VitruvioComponentsSelected;
+	TArray<UVitruvioComponent*> SelectedVitruvioComponents;
 	TWeakPtr<IDetailLayoutBuilder> CachedDetailBuilder;
 	TSharedPtr<SWidget> ColorPickerParentWidget;
 	TSharedPtr<STextComboBox> ChangeInitialShapeCombo;

--- a/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/VitruvioEditor/Public/VitruvioComponentDetails.h
@@ -67,12 +67,14 @@ public:
 	SLATE_ATTRIBUTE(TArray<TSharedPtr<T>>, ComboItemList)
 	SLATE_EVENT(SelectionChanged, OnSelectionChanged)
 	SLATE_ATTRIBUTE(TSharedPtr<T>, InitialValue)
+	SLATE_ATTRIBUTE(bool, HasMultipleValues)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
 
 private:
 	TArray<TSharedPtr<T>> ComboItemList;
+	bool HasMultipleValues;
 
 	TSharedRef<SWidget> OnGenerateComboWidget(TSharedPtr<T> InValue) const;
 };


### PR DESCRIPTION
- Changes made to VitruvioComponentDetails.cpp/h
- If the RPKs for the selected objects are different, it acts as before
- Otherwise, it now allows editing the multiple selected objects simultaneously
- Added a function to get all Vitruvio Components that are selected
- Added a function to determine if the selected Vitruvio Components have different values in its field
- Modified widget functions/Added new widget functions to account for multiple values selected