### PR TITLE
Fix collision for packaged builds

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
@@ -19,6 +19,7 @@
 #include "Materials/Material.h"
 #include "Runtime/CoreUObject/Public/UObject/ConstructorHelpers.h"
 #include "GenerateCompletedCallbackProxy.h"
+#include "PhysicsEngine/BodySetup.h"
 
 void UTile::MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
@@ -303,12 +304,11 @@ void AVitruvioBatchActor::ProcessGenerateQueue()
 
 		const FConvertedGenerateResult ConvertedResult = BuildGenerateResult(Item.GenerateResultDescription,
 	VitruvioModule::Get().GetMaterialCache(), VitruvioModule::Get().GetTextureCache(),
-				MaterialIdentifiers, UniqueMaterialIdentifiers, OpaqueParent, MaskedParent, TranslucentParent);
+				MaterialIdentifiers, UniqueMaterialIdentifiers, OpaqueParent, MaskedParent, TranslucentParent, GetWorld());
 
 		if (ConvertedResult.ShapeMesh)
 		{
 			VitruvioModelComponent->SetStaticMesh(ConvertedResult.ShapeMesh->GetStaticMesh());
-			VitruvioModelComponent->SetCollisionData(ConvertedResult.ShapeMesh->GetCollisionData());
 			
 			// Reset Material replacements
 			for (int32 MaterialIndex = 0; MaterialIndex < VitruvioModelComponent->GetNumMaterials(); ++MaterialIndex)
@@ -341,7 +341,6 @@ void AVitruvioBatchActor::ProcessGenerateQueue()
 																			  RF_Transient | RF_TextExportTransient | RF_DuplicateTransient);
 			const TArray<FTransform>& Transforms = Instance.Transforms;
 			InstancedComponent->SetStaticMesh(Instance.InstanceMesh->GetStaticMesh());
-			InstancedComponent->SetCollisionData(Instance.InstanceMesh->GetCollisionData());
 			InstancedComponent->SetMeshIdentifier(Instance.InstanceMesh->GetIdentifier());
 			
 			// Add all instance transforms

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/CustomCollisionProvider.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/CustomCollisionProvider.h
@@ -1,12 +1,18 @@
 #pragma once
 
-#include "VitruvioMesh.h"
-
+#include "VitruvioTypes.h"
 #include "Interfaces/Interface_CollisionDataProvider.h"
+#include "CustomCollisionProvider.generated.h"
 
-class VITRUVIO_API FCustomCollisionDataProvider : public IInterface_CollisionDataProvider
+UCLASS()
+class VITRUVIO_API UCustomCollisionDataProvider : public UObject, public IInterface_CollisionDataProvider
 {
-	virtual bool GetPhysicsTriMeshData(FTriMeshCollisionData* TriCollisionData, bool InUseAllTriData) override
+	GENERATED_BODY()
+
+protected:
+	Vitruvio::FCollisionData CollisionData;
+	
+	bool UpdateTrieMeshCollisionData(FTriMeshCollisionData* TriCollisionData) const
 	{
 		if (!CollisionData.IsValid())
 		{
@@ -21,18 +27,26 @@ class VITRUVIO_API FCustomCollisionDataProvider : public IInterface_CollisionDat
 		TriCollisionData->bFlipNormals = true;
 		return true;
 	}
+	
+public:
+
+	void SetCollisionData(const Vitruvio::FCollisionData& InCollisionData)
+	{
+		CollisionData = InCollisionData;
+	}
+
+	void ClearCollisionData()
+	{
+		CollisionData = {};
+	}
+
+	virtual bool GetPhysicsTriMeshData(FTriMeshCollisionData* TriCollisionData, bool InUseAllTriData) override
+	{
+		return UpdateTrieMeshCollisionData(TriCollisionData);
+	}
 
 	virtual bool ContainsPhysicsTriMeshData(bool InUseAllTriData) const override
 	{
 		return CollisionData.IsValid();
 	}
-
-public:
-	void SetCollisionData(const FCollisionData& InCollisionData)
-	{
-		CollisionData = InCollisionData;
-	}
-
-private:
-	FCollisionData CollisionData;
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelHISMComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelHISMComponent.h
@@ -15,14 +15,13 @@
 
 #pragma once
 
-#include "CustomCollisionProvider.h"
 #include "Components/HierarchicalInstancedStaticMeshComponent.h"
 #include "Interfaces/Interface_CollisionDataProvider.h"
 
 #include "GeneratedModelHISMComponent.generated.h"
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
-class VITRUVIO_API UGeneratedModelHISMComponent : public UHierarchicalInstancedStaticMeshComponent, public FCustomCollisionDataProvider
+class VITRUVIO_API UGeneratedModelHISMComponent : public UHierarchicalInstancedStaticMeshComponent
 {
 	GENERATED_BODY()
 	

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelStaticMeshComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GeneratedModelStaticMeshComponent.h
@@ -15,14 +15,14 @@
 
 #pragma once
 
-#include "CustomCollisionProvider.h"
 #include "Components/StaticMeshComponent.h"
 #include "Interfaces/Interface_CollisionDataProvider.h"
 
 #include "GeneratedModelStaticMeshComponent.generated.h"
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
-class VITRUVIO_API UGeneratedModelStaticMeshComponent : public UStaticMeshComponent, public FCustomCollisionDataProvider
+class VITRUVIO_API UGeneratedModelStaticMeshComponent : public UStaticMeshComponent
 {
 	GENERATED_BODY()
+	
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -93,7 +93,8 @@ FConvertedGenerateResult BuildGenerateResult(const FGenerateResultDescription& G
 									 TMap<FString, Vitruvio::FTextureData>& TextureCache,
 									 TMap<UMaterialInterface*, FString>& MaterialIdentifiers,
 									 TMap<FString, int32>& UniqueMaterialIdentifiers,
-									 UMaterial* OpaqueParent, UMaterial* MaskedParent, UMaterial* TranslucentParent);
+									 UMaterial* OpaqueParent, UMaterial* MaskedParent, UMaterial* TranslucentParent,
+									 UWorld* World);
 
 FString UniqueComponentName(const FString& Name, TMap<FString, int32>& UsedNames);
 
@@ -102,6 +103,8 @@ void ApplyMaterialReplacements(UStaticMeshComponent* StaticMeshComponent, const 
 
 TSet<FInstance> ApplyInstanceReplacements(UGeneratedModelStaticMeshComponent* GeneratedModelComponent, 
 											  const TArray<FInstance>& Instances, UInstanceReplacementAsset* Replacement, TMap<FString, int32>& NameMap);
+
+void InitializeBodySetup(UBodySetup* BodySetup);
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class VITRUVIO_API UVitruvioComponent : public UActorComponent

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioMesh.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioMesh.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "CustomCollisionProvider.h"
 #include "MeshDescription.h"
 #include "VitruvioTypes.h"
 #include "Runtime/PhysicsCore/Public/Interface_CollisionDataProviderCore.h"
@@ -26,17 +27,6 @@ UMaterialInstanceDynamic* CacheMaterial(UMaterial* OpaqueParent, UMaterial* Mask
 										const Vitruvio::FMaterialAttributeContainer& MaterialAttributes, TMap<FString, int32>& UniqueMaterialNames,
 										TMap<UMaterialInterface*, FString>& MaterialIdentifiers, UObject* Outer);
 
-struct FCollisionData
-{
-	TArray<FTriIndices> Indices;
-	TArray<FVector3f> Vertices;
-
-	bool IsValid() const
-	{
-		return Indices.Num() > 0 && Vertices.Num() > 0;
-	}
-};
-
 class FVitruvioMesh
 {
 	FString Identifier;
@@ -45,12 +35,12 @@ class FVitruvioMesh
 	TArray<Vitruvio::FMaterialAttributeContainer> Materials;
 
 	UStaticMesh* StaticMesh;
-	FCollisionData CollisionData;
+	UCustomCollisionDataProvider* CollisionDataProvider;
 
 public:
 	FVitruvioMesh(const FString& Identifier, const FMeshDescription& MeshDescription,
 				  const TArray<Vitruvio::FMaterialAttributeContainer>& Materials)
-		: Identifier(Identifier), MeshDescription(MeshDescription), Materials(Materials), StaticMesh(nullptr)
+		: Identifier(Identifier), MeshDescription(MeshDescription), Materials(Materials), StaticMesh(nullptr), CollisionDataProvider(nullptr)
 	{
 	}
 
@@ -71,12 +61,8 @@ public:
 		return StaticMesh;
 	}
 
-	const FCollisionData& GetCollisionData() const
-	{
-		return CollisionData;
-	}
-
 	void Build(const FString& Name, TMap<Vitruvio::FMaterialAttributeContainer, TObjectPtr<UMaterialInstanceDynamic>>& MaterialCache,
 			   TMap<FString, Vitruvio::FTextureData>& TextureCache, TMap<UMaterialInterface*, FString>& MaterialIdentifiers,
-			   TMap<FString, int32>& UniqueMaterialNames, UMaterial* OpaqueParent, UMaterial* MaskedParent, UMaterial* TranslucentParent);
+			   TMap<FString, int32>& UniqueMaterialNames, UMaterial* OpaqueParent, UMaterial* MaskedParent, UMaterial* TranslucentParent,
+			   UWorld* World);
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioTypes.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioTypes.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "Interface_CollisionDataProviderCore.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Misc/Paths.h"
 
@@ -158,6 +159,17 @@ struct FTextureData
 	friend bool operator!=(const FTextureData& Lhs, const FTextureData& RHS)
 	{
 		return !(Lhs == RHS);
+	}
+};
+
+struct FCollisionData
+{
+	TArray<FTriIndices> Indices;
+	TArray<FVector3f> Vertices;
+
+	bool IsValid() const
+	{
+		return Indices.Num() > 0 && Vertices.Num() > 0;
 	}
 };
 


### PR DESCRIPTION
Fixes:
- The parent of the `UBodySetup` needs to implement the IInterface_CollisionDataProvider to properly provide collision at runtime. We provide a custom `UObject` which implements the interface to tbe able to cache the collision data as well (since at the time of creating the meshes we don't have a `StaticMeshComponent` yet)
- The `IInterface_CollisionDataProvider` needs to be derived directly. Otherwise the internal `Cast` used to detect if the class implements this interface does not work correctly.