### PR TITLE
Add support for polygon initial shapes and simplify rule evaluation/generation

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -162,9 +162,17 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetSplineIniti
 	});
 }
 
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetPolygonInitialShape(UVitruvioComponent* VitruvioComponent, const FInitialShapePolygon& InitialShapePolygon, bool bGenerateModel)
+{
+	return ExecuteIfComponentValid(TEXT("SetSplineInitialShape"), VitruvioComponent, [InitialShapePolygon, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	{
+		VitruvioComponent->SetPolygonInitialShape(InitialShapePolygon, bGenerateModel, Proxy);
+	});
+}
+
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::ConvertToVitruvioActor(UObject* WorldContextObject, const TArray<AActor*>& Actors,
-																						 TArray<AVitruvioActor*>& OutVitruvioActors,
-																						 URulePackage* Rpk, bool bGenerateModels, bool bBatchGeneration)
+                                                                                         TArray<AVitruvioActor*>& OutVitruvioActors,
+                                                                                         URulePackage* Rpk, bool bGenerateModels, bool bBatchGeneration)
 {
 	UGenerateCompletedCallbackProxy* Proxy = NewObject<UGenerateCompletedCallbackProxy>();
 	Proxy->RegisterWithGameInstance(WorldContextObject);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/GenerateCompletedCallbackProxy.cpp
@@ -56,7 +56,7 @@ UGenerateCompletedCallbackProxy* ExecuteIfComponentValid(const FString& Function
 } // namespace
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage,
-																		 bool bGenerateModel)
+																		 bool bEvaluateAttributes, bool bGenerateModel)
 {
 	return ExecuteIfComponentValid(TEXT("SetRpk"), VitruvioComponent, [RulePackage, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
@@ -65,11 +65,11 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRpk(UVitruv
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetRandomSeed(UVitruvioComponent* VitruvioComponent, int32 NewRandomSeed,
-																				bool bGenerateModel)
+																				bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetRandomSeed"), VitruvioComponent, [NewRandomSeed, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetRandomSeed"), VitruvioComponent, [NewRandomSeed, bGenerateModel, bEvaluateAttributes](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetRandomSeed(NewRandomSeed, bGenerateModel, Proxy);
+		VitruvioComponent->SetRandomSeed(NewRandomSeed, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
@@ -82,91 +82,92 @@ UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::Generate(UVitr
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					float Value, bool bGenerateModel)
+	float Value, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetFloatAttribute"), VitruvioComponent, [&Name, &Value, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetFloatAttribute"), VitruvioComponent, [&Name, &Value, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetFloatAttribute(Name, Value, bGenerateModel, Proxy);
+		VitruvioComponent->SetFloatAttribute(Name, Value, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																					 const FString& Value, bool bGenerateModel)
+	const FString& Value, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetStringAttribute"), VitruvioComponent, [&Name, &Value, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetStringAttribute"), VitruvioComponent, [&Name, &Value, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetStringAttribute(Name, Value, bGenerateModel, Proxy);
+		VitruvioComponent->SetStringAttribute(Name, Value, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																				   bool Value, bool bGenerateModel)
+	bool Value, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetBoolAttribute"), VitruvioComponent, [&Name, &Value, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetBoolAttribute"), VitruvioComponent, [&Name, &Value, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetBoolAttribute(Name, Value, bGenerateModel, Proxy);
+		VitruvioComponent->SetBoolAttribute(Name, Value, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						 const TArray<double>& Values, bool bGenerateModel)
+	const TArray<double>& Values, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetFloatArrayAttribute"), VitruvioComponent, [&Name, &Values, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetFloatArrayAttribute"), VitruvioComponent, [&Name, &Values, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetFloatArrayAttribute(Name, Values, bGenerateModel, Proxy);
+		VitruvioComponent->SetFloatArrayAttribute(Name, Values, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						  const TArray<FString>& Values, bool bGenerateModel)
+	const TArray<FString>& Values, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetStringArrayAttribute"), VitruvioComponent, [&Name, &Values, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetStringArrayAttribute"), VitruvioComponent, [&Name, &Values, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetStringArrayAttribute(Name, Values, bGenerateModel, Proxy);
+		VitruvioComponent->SetStringArrayAttribute(Name, Values, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																						const TArray<bool>& Values, bool bGenerateModel)
+	const TArray<bool>& Values, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetBoolArrayAttribute"), VitruvioComponent, [&Name, &Values, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetBoolArrayAttribute"), VitruvioComponent, [&Name, &Values, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetBoolArrayAttribute(Name, Values, bGenerateModel, Proxy);
+		VitruvioComponent->SetBoolArrayAttribute(Name, Values, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetAttributes(UVitruvioComponent* VitruvioComponent,
-																				const TMap<FString, FString>& NewAttributes, bool bGenerateModel)
+	const TMap<FString, FString>& NewAttributes, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetAttributes"), VitruvioComponent, [&NewAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetAttributes"), VitruvioComponent, [&NewAttributes, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetAttributes(NewAttributes, bGenerateModel, Proxy);
+		VitruvioComponent->SetAttributes(NewAttributes, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh,
-																					  bool bGenerateModel)
+	bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetMeshInitialShape"), VitruvioComponent, [StaticMesh, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetMeshInitialShape"), VitruvioComponent, [StaticMesh, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetMeshInitialShape(StaticMesh, bGenerateModel, Proxy);
+		VitruvioComponent->SetMeshInitialShape(StaticMesh, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
 UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetSplineInitialShape(UVitruvioComponent* VitruvioComponent,
-																						const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel)
+	const TArray<FSplinePoint>& SplinePoints, bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetSplineInitialShape"), VitruvioComponent, [&SplinePoints, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetSplineInitialShape"), VitruvioComponent, [&SplinePoints, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetSplineInitialShape(SplinePoints, bGenerateModel, Proxy);
+		VitruvioComponent->SetSplineInitialShape(SplinePoints, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 
-UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetPolygonInitialShape(UVitruvioComponent* VitruvioComponent, const FInitialShapePolygon& InitialShapePolygon, bool bGenerateModel)
+UGenerateCompletedCallbackProxy* UGenerateCompletedCallbackProxy::SetPolygonInitialShape(UVitruvioComponent* VitruvioComponent, const FInitialShapePolygon& InitialShapePolygon,
+	bool bEvaluateAttributes, bool bGenerateModel)
 {
-	return ExecuteIfComponentValid(TEXT("SetSplineInitialShape"), VitruvioComponent, [InitialShapePolygon, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
+	return ExecuteIfComponentValid(TEXT("SetSplineInitialShape"), VitruvioComponent, [InitialShapePolygon, bEvaluateAttributes, bGenerateModel](UGenerateCompletedCallbackProxy* Proxy, UVitruvioComponent* VitruvioComponent)
 	{
-		VitruvioComponent->SetPolygonInitialShape(InitialShapePolygon, bGenerateModel, Proxy);
+		VitruvioComponent->SetPolygonInitialShape(InitialShapePolygon, bEvaluateAttributes, bGenerateModel, Proxy);
 	});
 }
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -698,3 +698,58 @@ void USplineInitialShape::UpdateSceneComponent(UVitruvioComponent* Component)
 		}
 	}
 }
+
+USceneComponent* UPolygonInitialShape::CreateInitialShapeComponent(UVitruvioComponent* Component)
+{
+	AActor* Owner = Component->GetOwner();
+	if (!Owner)
+	{
+		return nullptr;
+	}
+
+	if (USceneComponent* SceneComponent = Owner->FindComponentByClass<USceneComponent>())
+	{
+		return SceneComponent;
+	}
+	
+	const auto UniqueName = MakeUniqueObjectName(Owner, USceneComponent::StaticClass(), TEXT("InitialShapeComponent"));
+	USceneComponent* SceneComponent = AttachComponent<USceneComponent>(Owner, UniqueName.ToString());
+	return SceneComponent;
+}
+
+USceneComponent* UPolygonInitialShape::CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon&)
+{
+	return CreateInitialShapeComponent(Component);
+}
+
+void UPolygonInitialShape::UpdatePolygon(UVitruvioComponent* Component)
+{
+}
+
+void UPolygonInitialShape::UpdateSceneComponent(UVitruvioComponent* Component)
+{
+}
+
+bool UPolygonInitialShape::CanConstructFrom(AActor* Owner) const
+{
+	return false;
+}
+
+USceneComponent* UPolygonInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
+{
+	USceneComponent* NewSceneComponent = AttachComponent<USceneComponent>(NewActor, TEXT("InitialShapeComponent"), true, RF_Public);
+	return NewSceneComponent;
+}
+#if WITH_EDITOR
+bool UPolygonInitialShape::IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
+{
+	return false;
+}
+
+bool UPolygonInitialShape::ShouldConvert(const FInitialShapePolygon& InitialShapePolygon)
+{
+	return false;
+}
+#endif
+
+

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/InitialShape.cpp
@@ -707,27 +707,40 @@ USceneComponent* UPolygonInitialShape::CreateInitialShapeComponent(UVitruvioComp
 		return nullptr;
 	}
 
-	if (USceneComponent* SceneComponent = Owner->FindComponentByClass<USceneComponent>())
+	if (UPolygonSceneComponent* SceneComponent = Owner->FindComponentByClass<UPolygonSceneComponent>())
 	{
 		return SceneComponent;
 	}
 	
-	const auto UniqueName = MakeUniqueObjectName(Owner, USceneComponent::StaticClass(), TEXT("InitialShapeComponent"));
-	USceneComponent* SceneComponent = AttachComponent<USceneComponent>(Owner, UniqueName.ToString());
+	const auto UniqueName = MakeUniqueObjectName(Owner, UPolygonSceneComponent::StaticClass(), TEXT("InitialShapeComponent"));
+	UPolygonSceneComponent* SceneComponent = AttachComponent<UPolygonSceneComponent>(Owner, UniqueName.ToString());
 	return SceneComponent;
 }
 
-USceneComponent* UPolygonInitialShape::CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon&)
+USceneComponent* UPolygonInitialShape::CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon& NewPolygon)
 {
-	return CreateInitialShapeComponent(Component);
+	UPolygonSceneComponent* PolygonSceneComponent = Cast<UPolygonSceneComponent>(CreateInitialShapeComponent(Component));
+	PolygonSceneComponent->Polygon = NewPolygon;
+	return PolygonSceneComponent;
 }
 
 void UPolygonInitialShape::UpdatePolygon(UVitruvioComponent* Component)
 {
+	UPolygonSceneComponent* PolygonSceneComponent = Cast<UPolygonSceneComponent>(Component->InitialShapeSceneComponent);
+	SetPolygon(PolygonSceneComponent->Polygon);
 }
 
 void UPolygonInitialShape::UpdateSceneComponent(UVitruvioComponent* Component)
 {
+	if (UPolygonSceneComponent* PolygonSceneComponent = Cast<UPolygonSceneComponent>(Component->InitialShapeSceneComponent))
+	{
+		FInitialShapePolygon OldPolygon = PolygonSceneComponent->Polygon;
+
+		if (OldPolygon != GetPolygon())
+		{
+			PolygonSceneComponent->Polygon = GetPolygon();
+		}
+	}
 }
 
 bool UPolygonInitialShape::CanConstructFrom(AActor* Owner) const
@@ -737,9 +750,16 @@ bool UPolygonInitialShape::CanConstructFrom(AActor* Owner) const
 
 USceneComponent* UPolygonInitialShape::CopySceneComponent(AActor* OldActor, AActor* NewActor) const
 {
-	USceneComponent* NewSceneComponent = AttachComponent<USceneComponent>(NewActor, TEXT("InitialShapeComponent"), true, RF_Public);
+	UPolygonSceneComponent* NewSceneComponent = AttachComponent<UPolygonSceneComponent>(NewActor, TEXT("InitialShapeComponent"), true, RF_Public);
+
+	if (const UPolygonSceneComponent* OldSceneComponent = OldActor->FindComponentByClass<UPolygonSceneComponent>())
+	{
+		NewSceneComponent->Polygon = OldSceneComponent->Polygon;
+	}
+	
 	return NewSceneComponent;
 }
+
 #if WITH_EDITOR
 bool UPolygonInitialShape::IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent)
 {

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/Util/AttributeConversion.h
@@ -24,4 +24,6 @@ void UpdateAttributeMap(TMap<FString, URuleAttribute*>& AttributeMapOut, const A
 						UObject* const Outer);
 
 AttributeMapUPtr CreateAttributeMap(const TMap<FString, URuleAttribute*>& Attributes);
+URuleAttribute* CreateAttribute(const FString& Key, const FString& Value);
+
 } // namespace Vitruvio

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
@@ -21,18 +21,39 @@
 #include "GenerateCompletedCallbackProxy.h"
 #include "PhysicsEngine/BodySetup.h"
 
+void UTile::MarkForAttributeEvaluation(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	bMarkedForEvaluateAttributes = true;
+	if (CallbackProxy)
+	{
+		EvaluateAttributesCallbackProxies.Add(VitruvioComponent, CallbackProxy);
+	}
+}
+
+void UTile::UnmarkForAttributeEvaluation()
+{
+	bMarkedForEvaluateAttributes = false;
+	EvaluateAttributesCallbackProxies.Empty();
+}
+
 void UTile::MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
+	if (bMarkedForEvaluateAttributes)
+	{
+		UnmarkForAttributeEvaluation();
+	}
+	
 	bMarkedForGenerate = true;
 	if (CallbackProxy)
 	{
-		CallbackProxies.Add(VitruvioComponent, CallbackProxy);
+		GenerateCallbackProxies.Add(VitruvioComponent, CallbackProxy);
 	}
 }
 
 void UTile::UnmarkForGenerate()
 {
 	bMarkedForGenerate = false;
+	GenerateCallbackProxies.Empty();
 }
 
 void UTile::Add(UVitruvioComponent* VitruvioComponent)
@@ -57,7 +78,7 @@ TTuple<TArray<FInitialShape>, TArray<UVitruvioComponent*>> UTile::GetInitialShap
 	
 	for (UVitruvioComponent* VitruvioComponent : VitruvioComponents)
 	{
-		if (!VitruvioComponent->GetRpk())
+		if (!VitruvioComponent->HasValidInputData())
 		{
 			continue;
 		}
@@ -75,6 +96,23 @@ TTuple<TArray<FInitialShape>, TArray<UVitruvioComponent*>> UTile::GetInitialShap
 	}
 
 	return MakeTuple(MoveTemp(InitialShapes), ValidVitruvioComponents);
+}
+
+void FGrid::MarkForAttributeEvaluation(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	if (UTile** FoundTile = TilesByComponent.Find(VitruvioComponent))
+	{
+		UTile* Tile = *FoundTile;
+		Tile->MarkForAttributeEvaluation(VitruvioComponent, CallbackProxy);
+	}
+}
+
+void FGrid::MarkAllForAttributeEvaluation()
+{
+	for (const auto& [Component, Tile] : TilesByComponent)
+	{
+		Tile->MarkForGenerate(Component);
+	}
 }
 
 void FGrid::MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
@@ -167,22 +205,38 @@ void FGrid::Clear()
 TArray<UTile*> FGrid::GetTilesMarkedForGenerate() const
 {
 	TArray<UTile*> TilesToGenerate;
-	for (auto& [Point, Tile] : Tiles)
-	{
-		if (Tile->bMarkedForGenerate)
-		{
-			TilesToGenerate.Add(Tile);
-		}
-	}
+	Tiles.GenerateValueArray(TilesToGenerate);
 
-	return TilesToGenerate;
+	return TilesToGenerate.FilterByPredicate([](const UTile* Tile)
+	{
+		return Tile->bMarkedForGenerate;
+	});
 }
 
-void FGrid::UnmarkForGenerate()
+TArray<UTile*> FGrid::GetTilesMarkedForAttributeEvaluation() const
+{
+	TArray<UTile*> TilesToGenerate;
+	Tiles.GenerateValueArray(TilesToGenerate);
+
+	return TilesToGenerate.FilterByPredicate([](const UTile* Tile)
+	{
+		return Tile->bMarkedForEvaluateAttributes;
+	});
+}
+
+void FGrid::UnmarkAllForGenerate()
 {
 	for (auto& [Point, Tile] : Tiles)
 	{
 		Tile->UnmarkForGenerate();
+	}
+}
+
+void FGrid::UnmarkAllForAttributeEvaluation()
+{
+	for (auto& [Point, Tile] : Tiles)
+	{
+		Tile->UnmarkForAttributeEvaluation();
 	}
 }
 
@@ -246,10 +300,13 @@ void AVitruvioBatchActor::ProcessTiles()
 			Tile->GeneratedModelComponent = VitruvioModelComponent;
 		}
 
-		// Generate model
 		auto [InitialShapes, InitialShapeVitruvioComponents] = Tile->GetInitialShapes();
 		if (!InitialShapes.IsEmpty())
 		{
+			if (Tile->EvalAttributesToken)
+			{
+				Tile->EvalAttributesToken->Invalidate();
+			}
 			if (Tile->GenerateToken)
 			{
 				Tile->GenerateToken->Invalidate();
@@ -277,26 +334,64 @@ void AVitruvioBatchActor::ProcessTiles()
 
 				Tile->GenerateToken.Reset();
 
-				FScopeLock GenerateQueueLock(&WeakThis->ProcessQueueCriticalSection);
+				FScopeLock QueueLock(&WeakThis->ProcessGenerateQueueCriticalSection);
 				WeakThis->GenerateQueue.Enqueue({Result.Value, Tile, InitialShapeVitruvioComponents});
 			});
 			// clang-format on
 		}
 	}
 
-	Grid.UnmarkForGenerate();
+	for (UTile* Tile : Grid.GetTilesMarkedForAttributeEvaluation())
+	{
+		auto [InitialShapes, InitialShapeVitruvioComponents] = Tile->GetInitialShapes();
+		if (!InitialShapes.IsEmpty())
+		{
+			if (Tile->EvalAttributesToken)
+			{
+				Tile->EvalAttributesToken->Invalidate();
+			}
+			
+			FAttributeMapsResult AttributeMapsResult = VitruvioModule::Get().BatchEvaluateRuleAttributesAsync(MoveTemp(InitialShapes));
+			
+			Tile->EvalAttributesToken = AttributeMapsResult.Token;
+			Tile->bIsEvaluatingAttributes = true;
+
+			AttributeMapsResult.Result.Next([WeakThis = MakeWeakObjectPtr(this), Tile, InitialShapeVitruvioComponents](const FAttributeMapsResult::ResultType& Result)
+			{
+				if (!WeakThis.IsValid())
+				{
+					return;
+				}
+				
+				FScopeLock Lock(&Result.Token->Lock);
+
+				if (Result.Token->IsInvalid())
+				{
+					return;
+				}
+
+				Tile->EvalAttributesToken.Reset();
+
+				FScopeLock QueueLock(&WeakThis->ProcessAttributeEvaluationQueueCriticalSection);
+				WeakThis->AttributeEvaluationQueue.Enqueue({Result.Value, Tile, InitialShapeVitruvioComponents});
+			});
+		}
+	}
+	
+	Grid.UnmarkAllForGenerate();
+	Grid.UnmarkAllForAttributeEvaluation();
 }
 
 void AVitruvioBatchActor::ProcessGenerateQueue()
 {
-	ProcessQueueCriticalSection.Lock();
+	ProcessGenerateQueueCriticalSection.Lock();
 	
 	if (!GenerateQueue.IsEmpty())
 	{
 		FBatchGenerateQueueItem Item;
 		GenerateQueue.Dequeue(Item);
 
-		ProcessQueueCriticalSection.Unlock();
+		ProcessGenerateQueueCriticalSection.Unlock();
 
 		for (int ComponentIndex = 0; ComponentIndex < Item.VitruvioComponents.Num(); ++ComponentIndex)
 		{
@@ -369,19 +464,19 @@ void AVitruvioBatchActor::ProcessGenerateQueue()
 			InstancedComponent->RegisterComponent();
 		}
 
-		for (auto& [VitruvioComponent, CallbackProxy] : Item.Tile->CallbackProxies)
+		for (auto& [VitruvioComponent, CallbackProxy] : Item.Tile->GenerateCallbackProxies)
 		{
 			CallbackProxy->OnGenerateCompletedBlueprint.Broadcast();
 			CallbackProxy->OnGenerateCompleted.Broadcast();
 			CallbackProxy->SetReadyToDestroy();
 		}
 
-		Item.Tile->CallbackProxies.Empty();
+		Item.Tile->GenerateCallbackProxies.Empty();
 		Item.Tile->bIsGenerating = false;
 	}
 	else
 	{
-		ProcessQueueCriticalSection.Unlock();
+		ProcessGenerateQueueCriticalSection.Unlock();
 	}
 
 	if (GenerateAllCallbackProxy)
@@ -397,9 +492,36 @@ void AVitruvioBatchActor::ProcessGenerateQueue()
 	}
 }
 
+void AVitruvioBatchActor::ProcessAttributeEvaluationQueue()
+{
+	ProcessAttributeEvaluationQueueCriticalSection.Lock();
+	
+	if (!AttributeEvaluationQueue.IsEmpty())
+	{
+		FEvaluateAttributesQueueItem Item;
+		AttributeEvaluationQueue.Dequeue(Item);
+
+		ProcessAttributeEvaluationQueueCriticalSection.Unlock();
+
+		for (int ComponentIndex = 0; ComponentIndex < Item.VitruvioComponents.Num(); ++ComponentIndex)
+		{
+			UVitruvioComponent* VitruvioComponent = Item.VitruvioComponents[ComponentIndex];
+			Item.AttributeMaps[ComponentIndex]->UpdateUnrealAttributeMap(VitruvioComponent->Attributes, VitruvioComponent);
+			VitruvioComponent->bAttributesReady = true;
+			VitruvioComponent->NotifyAttributesChanged();
+		}
+	}
+	else
+	{
+		ProcessAttributeEvaluationQueueCriticalSection.Unlock();
+	}
+}
+
 void AVitruvioBatchActor::Tick(float DeltaSeconds)
 {
 	ProcessTiles();
+	
+	ProcessAttributeEvaluationQueue();
 	ProcessGenerateQueue();
 }
 
@@ -424,6 +546,17 @@ void AVitruvioBatchActor::UnregisterAllVitruvioComponents()
 TSet<UVitruvioComponent*> AVitruvioBatchActor::GetVitruvioComponents()
 {
 	return VitruvioComponents;
+}
+
+void AVitruvioBatchActor::EvaluateAttributes(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	Grid.MarkForAttributeEvaluation(VitruvioComponent, CallbackProxy);
+}
+
+void AVitruvioBatchActor::EvaluateAllAttributes(UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	EvaluateAllCallbackProxy = CallbackProxy;
+	Grid.MarkAllForAttributeEvaluation();
 }
 
 void AVitruvioBatchActor::Generate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
@@ -132,15 +132,15 @@ void FGrid::MarkAllForGenerate()
 	}
 }
 
-void FGrid::RegisterAll(const TSet<UVitruvioComponent*>& VitruvioComponents, AVitruvioBatchActor* VitruvioBatchActor)
+void FGrid::RegisterAll(const TSet<UVitruvioComponent*>& VitruvioComponents, AVitruvioBatchActor* VitruvioBatchActor, bool bGeneateModel)
 {
 	for (UVitruvioComponent* VitruvioComponent : VitruvioComponents)
 	{
-		Register(VitruvioComponent, VitruvioBatchActor);
+		Register(VitruvioComponent, VitruvioBatchActor, bGeneateModel);
 	} 
 }
 
-void FGrid::Register(UVitruvioComponent* VitruvioComponent, AVitruvioBatchActor* VitruvioBatchActor)
+void FGrid::Register(UVitruvioComponent* VitruvioComponent, AVitruvioBatchActor* VitruvioBatchActor, bool bGenerateModel)
 {
 	const FIntPoint Position = VitruvioBatchActor->GetPosition(VitruvioComponent);
 	
@@ -159,7 +159,10 @@ void FGrid::Register(UVitruvioComponent* VitruvioComponent, AVitruvioBatchActor*
 	if (!Tile->Contains(VitruvioComponent))
 	{
 		Tile->Add(VitruvioComponent);
-		Tile->MarkForGenerate(VitruvioComponent);
+		if (bGenerateModel)
+		{
+			Tile->MarkForGenerate(VitruvioComponent);
+		}
 		TilesByComponent.Add(VitruvioComponent, Tile);
 	}
 }
@@ -525,10 +528,15 @@ void AVitruvioBatchActor::Tick(float DeltaSeconds)
 	ProcessGenerateQueue();
 }
 
-void AVitruvioBatchActor::RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent)
+void AVitruvioBatchActor::RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent, bool bGenerateModel)
 {
+	if (VitruvioComponents.Contains(VitruvioComponent))
+	{
+		return;
+	}
+	
 	VitruvioComponents.Add(VitruvioComponent);
-	Grid.Register(VitruvioComponent, this);
+	Grid.Register(VitruvioComponent, this, bGenerateModel);
 }
 
 void AVitruvioBatchActor::UnregisterVitruvioComponent(UVitruvioComponent* VitruvioComponent)

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
@@ -71,7 +71,7 @@ AVitruvioBatchActor* UVitruvioBatchSubsystem::GetBatchActor()
 			
 			for (UVitruvioComponent* VitruvioComponent : RegisteredComponents)
 			{
-				VitruvioBatchActor->RegisterVitruvioComponent(VitruvioComponent);
+				RegisterVitruvioComponent(VitruvioComponent); 
 			}
 		}
 	}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
@@ -33,6 +33,16 @@ void UVitruvioBatchSubsystem::UnregisterVitruvioComponent(UVitruvioComponent* Vi
 	OnComponentDeregistered.Broadcast();
 }
 
+void UVitruvioBatchSubsystem::EvaluateAttributes(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	GetBatchActor()->EvaluateAttributes(VitruvioComponent, CallbackProxy);
+}
+
+void UVitruvioBatchSubsystem::EvaluateAllAttributes(UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	GetBatchActor()->EvaluateAllAttributes(CallbackProxy);
+}
+
 void UVitruvioBatchSubsystem::Generate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy)
 {
 	GetBatchActor()->Generate(VitruvioComponent, CallbackProxy);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchSubsystem.cpp
@@ -17,11 +17,11 @@
 
 #include "EngineUtils.h"
 
-void UVitruvioBatchSubsystem::RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent)
+void UVitruvioBatchSubsystem::RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent, bool bGenerateModel)
 {
+	GetBatchActor()->RegisterVitruvioComponent(VitruvioComponent, bGenerateModel);
+	
 	RegisteredComponents.Add(VitruvioComponent);
-	GetBatchActor()->RegisterVitruvioComponent(VitruvioComponent);
-
 	OnComponentRegistered.Broadcast();
 }
 
@@ -68,11 +68,11 @@ AVitruvioBatchActor* UVitruvioBatchSubsystem::GetBatchActor()
 			FActorSpawnParameters ActorSpawnParameters;
 			ActorSpawnParameters.Name = FName(TEXT("VitruvioBatchActor"));
 			VitruvioBatchActor = GetWorld()->SpawnActor<AVitruvioBatchActor>(ActorSpawnParameters);
-		}
-
-		for (UVitruvioComponent* VitruvioComponent : RegisteredComponents)
-		{
-			VitruvioBatchActor->RegisterVitruvioComponent(VitruvioComponent);
+			
+			for (UVitruvioComponent* VitruvioComponent : RegisteredComponents)
+			{
+				VitruvioBatchActor->RegisterVitruvioComponent(VitruvioComponent);
+			}
 		}
 	}
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -679,6 +679,17 @@ void UVitruvioComponent::SetSplineInitialShape(const TArray<FSplinePoint>& Splin
 	});
 }
 
+void UVitruvioComponent::SetPolygonInitialShape(const FInitialShapePolygon& InitialShapePolygon, bool bGenerateModel,
+	UGenerateCompletedCallbackProxy* CallbackProxy)
+{
+	SetInitialShape(this, bGenerateModel, CallbackProxy, [this, InitialShapePolygon]() {
+		UPolygonInitialShape* NewInitialShape =
+			NewObject<UPolygonInitialShape>(GetOwner(), UPolygonInitialShape::StaticClass(), NAME_None, RF_Transactional);
+		InitialShapeSceneComponent = NewInitialShape->CreateInitialShapeComponent(this, InitialShapePolygon);
+		return NewInitialShape;
+	});
+}
+
 const TMap<FString, URuleAttribute*>& UVitruvioComponent::GetAttributes() const
 {
 	return Attributes;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -67,6 +67,8 @@ void SetInitialShape(UVitruvioComponent* Component, bool bGenerateModel, UGenera
 
 	Component->InitialShape = NewInitialShape;
 
+	NewInitialShape->UpdatePolygon(Component);
+
 	Component->RemoveGeneratedMeshes();
 	Component->EvaluateRuleAttributes(bGenerateModel, CallbackProxy);
 }

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -721,7 +721,7 @@ TArray<FAttributeMapPtr> VitruvioModule::BatchEvaluateRuleAttributes(TArray<FIni
 		RuleInfoInitialShapes.Add(MakeTuple(StartRuleInfo, MoveTemp(InitialShapesByRpk)));
 	}
 	
-	auto ForeachInitialShape = [&RuleInfoInitialShapes](auto Fun)
+	auto ForeachInitialShape = [&](auto Fun)
 	{
 		int InitialShapeIndex = 0;
 		for (auto& [StartRuleInfo, InitialShapesByRpk] : RuleInfoInitialShapes)
@@ -739,7 +739,7 @@ TArray<FAttributeMapPtr> VitruvioModule::BatchEvaluateRuleAttributes(TArray<FIni
 	InitialShapeUPtrVector InitialShapeUPtrs;
 	InitialShapeNOPtrVector InitialShapePtrs;
 
-	ForeachInitialShape([&InitialShapeBuilders, &InitialShapeUPtrs, &InitialShapePtrs]
+	ForeachInitialShape([&]
 		(int32 InitialShapeIndex, const FInitialShape& InitialShape, const FStartRuleInfo& StartRuleInfo)
 	{
 		InitialShapeBuilderUPtr InitialShapeBuilder(prt::InitialShapeBuilder::create());
@@ -783,7 +783,7 @@ TArray<FAttributeMapPtr> VitruvioModule::BatchEvaluateRuleAttributes(TArray<FIni
 			return {};
 		}
 		
-		ForeachInitialShape([&EvaluateAttributeMapBuilders, &EvaluatedAttributes]
+		ForeachInitialShape([&]
 			(int32 InitialShapeIndex, const FInitialShape& InitialShape, const FStartRuleInfo& StartRuleInfo)
 		{
 			const FAttributeMapPtr AttributeMap = MakeShared<FAttributeMap>(

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioModule.cpp
@@ -564,6 +564,19 @@ FGenerateResultDescription VitruvioModule::BatchGenerate(TArray<FInitialShape> I
     	GenerateOutputHandler->GetInstanceMeshes(), GenerateOutputHandler->GetInstanceNames(), {}, EvaluatedAttributes };
 }
 
+FAttributeMapsResult VitruvioModule::BatchEvaluateRuleAttributesAsync(TArray<FInitialShape> InitialShapes) const
+{
+	FAttributeMapsResult::FTokenPtr InvalidationToken = MakeShared<FEvalAttributesToken>();
+
+	CHECK_PRT_INITIALIZED_ASYNC(FAttributeMapsResult, InvalidationToken)
+
+	FAttributeMapsResult::FFutureType AttributeMapPtrFuture = Async(EAsyncExecution::Thread, [this, InvalidationToken, InitialShapes = MoveTemp(InitialShapes)]() mutable {
+		TArray<FAttributeMapPtr> Result = BatchEvaluateRuleAttributes(MoveTemp(InitialShapes));
+		return FAttributeMapsResult::ResultType { InvalidationToken, MoveTemp(Result) };
+	});
+
+	return {MoveTemp(AttributeMapPtrFuture), InvalidationToken};
+}
 
 FGenerateResult VitruvioModule::GenerateAsync(FInitialShape InitialShape) const
 {
@@ -673,6 +686,118 @@ FAttributeMapResult VitruvioModule::EvaluateRuleAttributesAsync(FInitialShape In
 
 	return {MoveTemp(AttributeMapPtrFuture), InvalidationToken};
 }
+
+TArray<FAttributeMapPtr> VitruvioModule::BatchEvaluateRuleAttributes(TArray<FInitialShape> InitialShapes) const
+{
+	CHECK_PRT_INITIALIZED()
+	
+	LoadAttributesCounter.Add(InitialShapes.Num());
+
+	TMap<URulePackage*, TArray<FInitialShape>> RulePackages;
+	for (FInitialShape& InitialShape : InitialShapes)
+	{
+		RulePackages.FindOrAdd(InitialShape.RulePackage).Add(MoveTemp(InitialShape));
+	}
+
+	TArray<TTuple<TFuture<ResolveMapSPtr>, TArray<FInitialShape>>> ResolveMapFutures;
+	for (auto& [RulePackage, InitialShapesByRpk] : RulePackages)
+	{
+		ResolveMapFutures.Add(MakeTuple(LoadResolveMapAsync(RulePackage), MoveTemp(InitialShapesByRpk)));
+	}
+
+	TArray<TTuple<FStartRuleInfo, TArray<FInitialShape>>> RuleInfoInitialShapes;
+	for (auto& [ResolveMapFuture, InitialShapesByRpk] : ResolveMapFutures)
+	{
+		const ResolveMapSPtr ResolveMap = ResolveMapFuture.Get();
+
+		const std::wstring RuleFile = ResolveMap->findCGBKey();
+		const wchar_t* RuleFileUri = ResolveMap->getString(RuleFile.c_str());
+
+		const RuleFileInfoPtr RuleFileInfo = prt_make_shared<const prt::RuleFileInfo>(prt::createRuleFileInfo(RuleFileUri));
+		const std::wstring StartRule = prtu::detectStartRule(RuleFileInfo);
+		
+		FStartRuleInfo StartRuleInfo { ResolveMap, RuleFile.c_str(), StartRule.c_str(), RuleFileInfo };
+
+		RuleInfoInitialShapes.Add(MakeTuple(StartRuleInfo, MoveTemp(InitialShapesByRpk)));
+	}
+	
+	auto ForeachInitialShape = [&RuleInfoInitialShapes](auto Fun)
+	{
+		int InitialShapeIndex = 0;
+		for (auto& [StartRuleInfo, InitialShapesByRpk] : RuleInfoInitialShapes)
+		{
+			for (const FInitialShape& InitialShape : InitialShapesByRpk)
+			{
+				Fun(InitialShapeIndex, InitialShape, StartRuleInfo);
+
+				InitialShapeIndex++;
+			}
+		}
+	};
+	
+	TArray<InitialShapeBuilderUPtr> InitialShapeBuilders;
+	InitialShapeUPtrVector InitialShapeUPtrs;
+	InitialShapeNOPtrVector InitialShapePtrs;
+
+	ForeachInitialShape([&InitialShapeBuilders, &InitialShapeUPtrs, &InitialShapePtrs]
+		(int32 InitialShapeIndex, const FInitialShape& InitialShape, const FStartRuleInfo& StartRuleInfo)
+	{
+		InitialShapeBuilderUPtr InitialShapeBuilder(prt::InitialShapeBuilder::create());
+		SetInitialShapeGeometry(InitialShapeBuilder, InitialShape);
+		InitialShapeBuilder->setAttributes(*StartRuleInfo.RuleFile, *StartRuleInfo.StartRule, InitialShape.RandomSeed, L"",
+			InitialShape.Attributes.get(), StartRuleInfo.ResolveMap.get());
+		InitialShapeUPtr Shape(InitialShapeBuilder->createInitialShape());
+		InitialShapePtrs.push_back(Shape.get());
+		InitialShapeUPtrs.push_back(std::move(Shape));
+
+		InitialShapeBuilders.Add(MoveTemp(InitialShapeBuilder));
+	});
+
+	TArray<FAttributeMapPtr> EvaluatedAttributes;
+	
+	// Evaluate attributes
+	{
+		TArray<AttributeMapBuilderUPtr> EvaluateAttributeMapBuilders;
+		for (int32 InitialShapeIndex = 0; InitialShapeIndex < InitialShapes.Num(); ++InitialShapeIndex)
+		{
+			EvaluateAttributeMapBuilders.Add(AttributeMapBuilderUPtr(prt::AttributeMapBuilder::create()));
+		}
+		TSharedPtr<UnrealCallbacks> OutputHandler(new UnrealCallbacks(EvaluateAttributeMapBuilders));
+		
+		const std::vector EncoderIds = { ATTRIBUTE_EVAL_ENCODER_ID };
+		const AttributeMapUPtr AttributeEncodeOptions = prtu::createValidatedOptions(ATTRIBUTE_EVAL_ENCODER_ID);
+		const AttributeMapNOPtrVector EncoderOptions = {AttributeEncodeOptions.get()};
+
+		AttributeMapBuilderUPtr GenerateOptionsBuilder(prt::AttributeMapBuilder::create());
+		GenerateOptionsBuilder->setInt(L"numberWorkerThreads", FPlatformMisc::NumberOfCores());
+		const AttributeMapUPtr GenerateOptions(GenerateOptionsBuilder->createAttributeMapAndReset());
+
+		prt::Status GenerateStatus = generate(InitialShapePtrs.data(), InitialShapePtrs.size(), nullptr, EncoderIds.data(),
+			EncoderIds.size(), EncoderOptions.data(), OutputHandler.Get(),
+					  PrtCache.get(), nullptr, GenerateOptions.get());
+
+		if (GenerateStatus != prt::STATUS_OK)
+		{
+			LoadAttributesCounter.Subtract(InitialShapes.Num());
+			UE_LOG(LogUnrealPrt, Error, TEXT("PRT generate failed: %hs"), prt::getStatusDescription(GenerateStatus))
+			return {};
+		}
+		
+		ForeachInitialShape([&EvaluateAttributeMapBuilders, &EvaluatedAttributes]
+			(int32 InitialShapeIndex, const FInitialShape& InitialShape, const FStartRuleInfo& StartRuleInfo)
+		{
+			const FAttributeMapPtr AttributeMap = MakeShared<FAttributeMap>(
+				AttributeMapUPtr(EvaluateAttributeMapBuilders[InitialShapeIndex]->createAttributeMapAndReset()),
+				StartRuleInfo.RuleFileInfo);
+			EvaluatedAttributes.Add(AttributeMap);
+		});
+	}
+
+	LoadAttributesCounter.Subtract(InitialShapes.Num());
+
+	return EvaluatedAttributes;
+}
+
 
 void VitruvioModule::EvictFromResolveMapCache(URulePackage* RulePackage)
 {

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -71,17 +71,16 @@ public:
 	 * Sets the given Rule Package. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage, bool bGenerateModel = true);
+	static UGenerateCompletedCallbackProxy* SetRpk(UVitruvioComponent* VitruvioComponent, URulePackage* RulePackage, bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the random seed used for generation. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
-	static UGenerateCompletedCallbackProxy* SetRandomSeed(UVitruvioComponent* VitruvioComponent, int32 NewRandomSeed, bool bGenerateModel = true);
+	static UGenerateCompletedCallbackProxy* SetRandomSeed(UVitruvioComponent* VitruvioComponent, int32 NewRandomSeed, bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
-	 * Generates a model using the current Rule Package and initial shape. If the attributes are not yet available, they will first be evaluated. If
-	 * no Initial Shape or Rule Package is set, this method will do nothing.
+	 * Generates a model using the current Rule Package and initial shape. If no Initial Shape or Rule Package is set, this method will do nothing.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* Generate(UVitruvioComponent* VitruvioComponent, FGenerateOptions GenerateOptions);
@@ -97,7 +96,7 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, float Value,
-															  bool bGenerateModel = true);
+															  bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the string attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
@@ -110,7 +109,7 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, const FString& Value,
-															   bool bGenerateModel = true);
+															   bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the bool attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
@@ -118,12 +117,13 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name, bool Value,
-															 bool bGenerateModel = true);
+															 bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
@@ -131,12 +131,13 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetFloatArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																   const TArray<double>& Values, bool bGenerateModel = true);
+																   const TArray<double>& Values, bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets a string array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
@@ -144,12 +145,13 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetStringArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																	const TArray<FString>& Values, bool bGenerateModel = true);
+																	const TArray<FString>& Values, bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets a bool array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
@@ -157,12 +159,13 @@ public:
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetBoolArrayAttribute(UVitruvioComponent* VitruvioComponent, const FString& Name,
-																  const TArray<bool>& Values, bool bGenerateModel = true);
+																  const TArray<bool>& Values, bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the given attributes. If a key from the NewAttributes is not found in the current attributes, the key-value pair will be ignored.
@@ -171,48 +174,52 @@ public:
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the attribute is set.
 	 * @param NewAttributes The attributes to be set.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attributes have been set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<FString, FString>& NewAttributes,
-														  bool bGenerateModel = true);
+														  bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param StaticMesh The new initial shape static mesh.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetMeshInitialShape(UVitruvioComponent* VitruvioComponent, UStaticMesh* StaticMesh,
-																bool bGenerateModel = true);
+																bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the given spline points as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param SplinePoints The new initial shape spline points.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetSplineInitialShape(UVitruvioComponent* VitruvioComponent, const TArray<FSplinePoint>& SplinePoints,
-																  bool bGenerateModel = true);
+																  bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
 	 * @param InitialShapePolygon the new initial shape polygon.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
 	 * @returns a callback proxy used to register for completion events.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
 	static UGenerateCompletedCallbackProxy* SetPolygonInitialShape(UVitruvioComponent* VitruvioComponent, const FInitialShapePolygon& InitialShapePolygon,
-																bool bGenerateModel = true);
+																bool bEvaluateAttributes, bool bGenerateModel = true);
 
 	/**
 	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (see

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/GenerateCompletedCallbackProxy.h
@@ -203,6 +203,18 @@ public:
 																  bool bGenerateModel = true);
 
 	/**
+	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
+	 *
+	 * @param VitruvioComponent The VitruvioComponent where the initial shape is set.
+	 * @param InitialShapePolygon the new initial shape polygon.
+	 * @param bGenerateModel Whether a model should be generated after the initial shape has set.
+	 * @returns a callback proxy used to register for completion events.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = true), Category = "Vitruvio")
+	static UGenerateCompletedCallbackProxy* SetPolygonInitialShape(UVitruvioComponent* VitruvioComponent, const FInitialShapePolygon& InitialShapePolygon,
+																bool bGenerateModel = true);
+
+	/**
 	 * Converts the given Actors to VitruvioActors and optionally assigns the given RulePackage. If an Actor can not be converted (see
 	 * CanConvertToVitruvioActor) it will be ignored.
 	 *

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -221,6 +221,15 @@ public:
 };
 
 UCLASS()
+class UPolygonSceneComponent : public USceneComponent
+{
+	GENERATED_BODY()
+
+public:
+	FInitialShapePolygon Polygon;
+};
+
+UCLASS()
 class VITRUVIO_API UPolygonInitialShape : public UInitialShape
 {
 public:

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -21,12 +21,12 @@
 
 class UVitruvioComponent;
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VITRUVIO_API FTextureCoordinateSet
 {
 	GENERATED_BODY()
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<FVector2f> TextureCoordinates;
 
 	friend bool operator==(const FTextureCoordinateSet& Lhs, const FTextureCoordinateSet& RHS)
@@ -40,12 +40,12 @@ struct VITRUVIO_API FTextureCoordinateSet
 	}
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VITRUVIO_API FInitialShapeHole
 {
 	GENERATED_BODY()
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<int32> Indices;
 
 	friend bool operator==(const FInitialShapeHole& Lhs, const FInitialShapeHole& RHS)
@@ -59,15 +59,15 @@ struct VITRUVIO_API FInitialShapeHole
 	}
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VITRUVIO_API FInitialShapeFace
 {
 	GENERATED_BODY()
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<int32> Indices;
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<FInitialShapeHole> Holes;
 
 	friend bool operator==(const FInitialShapeFace& Lhs, const FInitialShapeFace& RHS)
@@ -81,18 +81,18 @@ struct VITRUVIO_API FInitialShapeFace
 	}
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VITRUVIO_API FInitialShapePolygon
 {
 	GENERATED_BODY()
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<FInitialShapeFace> Faces;
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<FVector> Vertices;
 
-	UPROPERTY()
+	UPROPERTY(BlueprintReadWrite)
 	TArray<FTextureCoordinateSet> TextureCoordinateSets;
 
 	void FixOrientation();
@@ -209,6 +209,25 @@ public:
 
 	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component) override;
 	USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const TArray<FSplinePoint>& SplinePoints);
+	virtual void UpdatePolygon(UVitruvioComponent* Component) override;
+	virtual void UpdateSceneComponent(UVitruvioComponent* Component) override;
+	virtual bool CanConstructFrom(AActor* Owner) const override;
+	virtual USceneComponent* CopySceneComponent(AActor* OldActor, AActor* NewActor) const override;
+
+#if WITH_EDITOR
+	virtual bool IsRelevantProperty(UObject* Object, const FPropertyChangedEvent& PropertyChangedEvent) override;
+	virtual bool ShouldConvert(const FInitialShapePolygon& InitialShapePolygon) override;
+#endif
+};
+
+UCLASS()
+class VITRUVIO_API UPolygonInitialShape : public UInitialShape
+{
+public:
+	GENERATED_BODY()
+
+	virtual USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component) override;
+	USceneComponent* CreateInitialShapeComponent(UVitruvioComponent* Component, const FInitialShapePolygon& InitialShapePolygon);
 	virtual void UpdatePolygon(UVitruvioComponent* Component) override;
 	virtual void UpdateSceneComponent(UVitruvioComponent* Component) override;
 	virtual bool CanConstructFrom(AActor* Owner) const override;

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/InitialShape.h
@@ -26,7 +26,7 @@ struct VITRUVIO_API FTextureCoordinateSet
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<FVector2f> TextureCoordinates;
 
 	friend bool operator==(const FTextureCoordinateSet& Lhs, const FTextureCoordinateSet& RHS)
@@ -45,7 +45,7 @@ struct VITRUVIO_API FInitialShapeHole
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<int32> Indices;
 
 	friend bool operator==(const FInitialShapeHole& Lhs, const FInitialShapeHole& RHS)
@@ -64,10 +64,10 @@ struct VITRUVIO_API FInitialShapeFace
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<int32> Indices;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<FInitialShapeHole> Holes;
 
 	friend bool operator==(const FInitialShapeFace& Lhs, const FInitialShapeFace& RHS)
@@ -86,13 +86,13 @@ struct VITRUVIO_API FInitialShapePolygon
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<FInitialShapeFace> Faces;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<FVector> Vertices;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "Vitruvio")
 	TArray<FTextureCoordinateSet> TextureCoordinateSets;
 
 	void FixOrientation();

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchActor.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchActor.h
@@ -38,14 +38,24 @@ public:
 	bool bMarkedForGenerate;
 	bool bIsGenerating;
 
+	UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Category = "Vitruvio")
+	bool bMarkedForEvaluateAttributes;
+	bool bIsEvaluatingAttributes;
+
 	UPROPERTY()
-	TMap<UVitruvioComponent*, UGenerateCompletedCallbackProxy*> CallbackProxies;
+	TMap<UVitruvioComponent*, UGenerateCompletedCallbackProxy*> GenerateCallbackProxies;
+	UPROPERTY()
+	TMap<UVitruvioComponent*, UGenerateCompletedCallbackProxy*> EvaluateAttributesCallbackProxies;
 
 	FBatchGenerateResult::FTokenPtr GenerateToken;
+	FAttributeMapsResult::FTokenPtr EvalAttributesToken;
 
 	UPROPERTY()
 	UGeneratedModelStaticMeshComponent* GeneratedModelComponent;
-    	
+
+	void MarkForAttributeEvaluation(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void UnmarkForAttributeEvaluation();
+	
 	void MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	void UnmarkForGenerate();
 	
@@ -66,6 +76,9 @@ struct FGrid
 	UPROPERTY()
 	TMap<UVitruvioComponent*, UTile*> TilesByComponent;
 
+	void MarkForAttributeEvaluation(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void MarkAllForAttributeEvaluation();
+
 	void MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	void MarkAllForGenerate();
 	
@@ -76,12 +89,22 @@ struct FGrid
 	void Clear();
 
 	TArray<UTile*> GetTilesMarkedForGenerate() const;
-	void UnmarkForGenerate();
+	TArray<UTile*> GetTilesMarkedForAttributeEvaluation() const;
+	
+	void UnmarkAllForGenerate();
+	void UnmarkAllForAttributeEvaluation();
 };
 
 struct FBatchGenerateQueueItem
 {
 	FGenerateResultDescription GenerateResultDescription;
+	UTile* Tile;
+	TArray<UVitruvioComponent*> VitruvioComponents;
+};
+
+struct FEvaluateAttributesQueueItem
+{
+	TArray<FAttributeMapPtr> AttributeMaps;
 	UTile* Tile;
 	TArray<UVitruvioComponent*> VitruvioComponents;
 };
@@ -105,6 +128,7 @@ private:
 	FGrid Grid;
 
 	TQueue<FBatchGenerateQueueItem> GenerateQueue;
+	TQueue<FEvaluateAttributesQueueItem> AttributeEvaluationQueue;
 
 	UPROPERTY(Transient)
 	TMap<UMaterialInterface*, FString> MaterialIdentifiers;
@@ -144,6 +168,9 @@ public:
 	void UnregisterAllVitruvioComponents();
 	TSet<UVitruvioComponent*> GetVitruvioComponents();
 
+	void EvaluateAttributes(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void EvaluateAllAttributes(UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	
 	void Generate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	void GenerateAll(UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	
@@ -172,9 +199,13 @@ public:
 private:
 	void ProcessTiles();
 	void ProcessGenerateQueue();
+	void ProcessAttributeEvaluationQueue();
 
-	FCriticalSection ProcessQueueCriticalSection;
+	FCriticalSection ProcessGenerateQueueCriticalSection;
+	FCriticalSection ProcessAttributeEvaluationQueueCriticalSection;
 
 	UPROPERTY()
 	UGenerateCompletedCallbackProxy* GenerateAllCallbackProxy;
+	UPROPERTY()
+	UGenerateCompletedCallbackProxy* EvaluateAllCallbackProxy;
 };

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchActor.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchActor.h
@@ -82,8 +82,8 @@ struct FGrid
 	void MarkForGenerate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	void MarkAllForGenerate();
 	
-	void RegisterAll(const TSet<UVitruvioComponent*>& VitruvioComponents, AVitruvioBatchActor* VitruvioBatchActor);
-	void Register(UVitruvioComponent* VitruvioComponent, AVitruvioBatchActor* VitruvioBatchActor);
+	void RegisterAll(const TSet<UVitruvioComponent*>& VitruvioComponents, AVitruvioBatchActor* VitruvioBatchActor, bool bGeneateModel = true);
+	void Register(UVitruvioComponent* VitruvioComponent, AVitruvioBatchActor* VitruvioBatchActor, bool bGeneateModel = true);
 	void Unregister(UVitruvioComponent* VitruvioComponent);
 
 	void Clear();
@@ -163,7 +163,7 @@ public:
 
 	virtual void Tick(float DeltaSeconds) override;
 
-	void RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
+	void RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent, bool bGenerateModel = true);
 	void UnregisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
 	void UnregisterAllVitruvioComponents();
 	TSet<UVitruvioComponent*> GetVitruvioComponents();

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchSubsystem.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchSubsystem.h
@@ -32,7 +32,7 @@ public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 	
-	void RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
+	void RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent, bool bGenerateModel = true);
 	void UnregisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
 
 	void EvaluateAttributes(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchSubsystem.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioBatchSubsystem.h
@@ -34,6 +34,10 @@ public:
 	
 	void RegisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
 	void UnregisterVitruvioComponent(UVitruvioComponent* VitruvioComponent);
+
+	void EvaluateAttributes(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void EvaluateAllAttributes(UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	
 	void Generate(UVitruvioComponent* VitruvioComponent, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 	void GenerateAll(UGenerateCompletedCallbackProxy* CallbackProxy);
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -367,8 +367,16 @@ public:
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel = true,
-							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+
+	/**
+	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
+	 *
+	 * @param InitialShapePolygon the new initial shape polygon.
+	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
+	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
+	 */
+	void SetPolygonInitialShape(const FInitialShapePolygon& InitialShapePolygon, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/** Returns the attributes used for generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioComponent.h
@@ -170,7 +170,7 @@ public:
 	 * Enables or disables batch generation.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
-	void SetBatchGenerated(bool bBatchGeneration);
+	void SetBatchGenerated(bool bBatchGeneration, bool bGenerateModel = true);
 
 	/**
 	 * Returns whether batch generation is enabled.
@@ -210,14 +210,15 @@ public:
 	bool IsReadyToGenerate() const;
 
 	/**
-	 * Sets the string attribute with the given Name to the given value. Regenerates the model if GenerateAutomatically is set to true.
+	 * Sets the string attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute to set.
 	 * @param Value The new value for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The callback proxy used to register for completion events.
 	 */
-	void SetStringAttribute(const FString& Name, const FString& Value, bool bGenerateModel = true,
+	void SetStringAttribute(const FString& Name, const FString& Value, bool bEvaluateAttributes = true, bool bGenerateModel = true,
 							UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
@@ -235,11 +236,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bGenerateModel = true,
+	void SetStringArrayAttribute(const FString& Name, const TArray<FString>& Values, bool bEvaluateAttributes = true, bool bGenerateModel = true,
 								 UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
@@ -257,11 +259,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Value The new value for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolAttribute(const FString& Name, bool Value, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetBoolAttribute(const FString& Name, bool Value, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the bool attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -278,11 +281,12 @@ public:
 	 *
 	 * @param Name The name of the attribute.
 	 * @param Values The new values for the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bGenerateModel = true,
+	void SetBoolArrayAttribute(const FString& Name, const TArray<bool>& Values, bool bEvaluateAttributes = true, bool bGenerateModel = true,
 							   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
@@ -299,12 +303,13 @@ public:
 	 * Sets the float attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param Value The new value for the attribute.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatAttribute(const FString& Name, double Value, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetFloatAttribute(const FString& Name, double Value, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Access the float attribute with the given Name. The OutValue is default initialized if no attribute with the given Name is found.
@@ -320,12 +325,13 @@ public:
 	 * Sets the float array attribute with the given Name to the given value. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param Name The name of the attribute.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param Values The new values for the attribute.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 * @returns true if the attribute has been set to the new value or false otherwise.
 	 */
-	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bGenerateModel = true,
+	void SetFloatArrayAttribute(const FString& Name, const TArray<double>& Values, bool bEvaluateAttributes = true, bool bGenerateModel = true,
 								UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
@@ -345,38 +351,42 @@ public:
 	 * array values are separated via a comma eg: "1.3,4.5,0" for a float array with the values 1.3, 4.5 and 0.
 	 *
 	 * @param NewAttributes The attributes to be set.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetAttributes(const TMap<FString, FString>& NewAttributes, bool bGenerateModel = true,
+	void SetAttributes(const TMap<FString, FString>& NewAttributes, bool bEvaluateAttributes = true, bool bGenerateModel = true,
 					   UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param StaticMesh the new initial shape static mesh.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetMeshInitialShape(UStaticMesh* StaticMesh, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetMeshInitialShape(UStaticMesh* StaticMesh, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given spline points as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param SplinePoints the new initial shape spline points.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetSplineInitialShape(const TArray<FSplinePoint>& SplinePoints, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/**
 	 * Sets the given static mesh as initial shape. Regenerates the model if bGenerateModel is set to true.
 	 *
 	 * @param InitialShapePolygon the new initial shape polygon.
+	 * @param bEvaluateAttributes Whether the attributes should be re-evaluated after the initial shape has been set.
 	 * @param bGenerateModel Whether a model should be generated after the attribute has been set.
 	 * @param CallbackProxy The optional callback proxy used for generate completed notifications.
 	 */
-	void SetPolygonInitialShape(const FInitialShapePolygon& InitialShapePolygon, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetPolygonInitialShape(const FInitialShapePolygon& InitialShapePolygon, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	/** Returns the attributes used for generation. */
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
@@ -397,7 +407,7 @@ public:
 	/**
 	 * Sets the random seed used for generation. This will reevaluate the attributes and if bGenerateModel is set to true, also generates the model.
 	 */
-	void SetRandomSeed(int32 NewRandomSeed, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
+	void SetRandomSeed(int32 NewRandomSeed, bool bEvaluateAttributes = true, bool bGenerateModel = true, UGenerateCompletedCallbackProxy* CallbackProxy = nullptr);
 
 	UFUNCTION(BlueprintCallable, Category = "Vitruvio")
 	/** Returns the random seed used for generation. */

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Public/VitruvioModule.h
@@ -108,6 +108,7 @@ struct FInitialShape
 using FGenerateResult = TResult<FGenerateResultDescription, FGenerateToken>;
 using FBatchGenerateResult = TResult<FGenerateResultDescription, FGenerateToken>;
 using FAttributeMapResult = TResult<FAttributeMapPtr, FEvalAttributesToken>;
+using FAttributeMapsResult = TResult<TArray<FAttributeMapPtr>, FEvalAttributesToken>;
 
 class VitruvioModule final : public IModuleInterface, public FGCObject
 {
@@ -139,13 +140,26 @@ public:
 	VITRUVIO_API FGenerateResultDescription BatchGenerate(TArray<FInitialShape> InitialShapes) const;
 
 	/**
+	 * \brief Asynchronously Evaluates attributes for the given initial shapes and rule packages.
+	 *
+	 * \param InitialShapes
+	 */
+	VITRUVIO_API FAttributeMapsResult BatchEvaluateRuleAttributesAsync(TArray<FInitialShape> InitialShapes) const;
+	
+	/**
+	 * \brief Evaluates attributes for the given initial shapes and rule package.
+	 *
+	 * \param InitialShapes
+	 */
+	VITRUVIO_API TArray<FAttributeMapPtr> BatchEvaluateRuleAttributes(TArray<FInitialShape> InitialShapes) const;
+
+	/**
 	 * \brief Asynchronously generate the models with the given InitialShape, RulePackage and Attributes.
 	 *
 	 * \param InitialShape
 	 * \return the generated UStaticMesh.
 	 */
 	VITRUVIO_API FGenerateResult GenerateAsync(FInitialShape InitialShape) const;
-
 
 	/**
 	 * \brief Generate the models with the given InitialShape, RulePackage and Attributes.

--- a/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
+++ b/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 6,
-	"VersionName": "2.2 - 2023.1 (CE SDK v3.2.10650)",
+	"VersionName": "2.2.1 - 2024.1 (CE SDK v3.2.10650)",
 	"FriendlyName": "ArcGIS CityEngine for Unreal Engine",
 	"Description": "ArcGIS CityEngine for Unreal Engine adds support for CityEngine's procedural runtime (PRT).",
 	"Category": "Misc",

--- a/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
+++ b/VitruvioHost/Plugins/Vitruvio/Vitruvio.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 6,
-	"VersionName": "2.2.1 - 2024.1 (CE SDK v3.2.10650)",
+	"VersionName": "2.3 - 2024.1 (CE SDK v3.2.10650)",
 	"FriendlyName": "ArcGIS CityEngine for Unreal Engine",
 	"Description": "ArcGIS CityEngine for Unreal Engine adds support for CityEngine's procedural runtime (PRT).",
 	"Category": "Misc",


### PR DESCRIPTION
- Adds support for polygon based initial shapes (used to create VitruvioActors at runtime in C++ or Blueprints via `SetPolygonInitialShape`)
- Simplify and extend control over automatic rule attribute evaluation
  - When creating VitruvioActors at runtime we need easy control when attributes are evaluated and when not to reduce unnecessary generate calls which can be expensive. Eg. we want to first setup all necessary input (initial shape, certain attributes etc.) before generating the model. Previously we used to automatically evaluate attributes if they have not been set when for example trying to update a certain attribute value.